### PR TITLE
fix shader build order

### DIFF
--- a/samples/simple_raytracer/build.zig
+++ b/samples/simple_raytracer/build.zig
@@ -30,9 +30,10 @@ pub fn build(b: *std.build.Builder) void {
     b.installFile("../../external/bin/d3d12/D3D12Core.pdb", "bin/d3d12/D3D12Core.pdb");
     b.installFile("../../external/bin/d3d12/D3D12SDKLayers.dll", "bin/d3d12/D3D12SDKLayers.dll");
     b.installFile("../../external/bin/d3d12/D3D12SDKLayers.pdb", "bin/d3d12/D3D12SDKLayers.pdb");
-    b.installDirectory(
+    const install_content_step = b.addInstallDirectory(
         .{ .source_dir = "content", .install_dir = .{ .custom = "" }, .install_subdir = "bin/content" },
     );
+    b.getInstallStep().dependOn(&install_content_step.step);
 
     const dxc_step = b.step("dxc", "Build shaders");
 
@@ -110,7 +111,7 @@ pub fn build(b: *std.build.Builder) void {
     );
     dxc_step.dependOn(&b.addSystemCommand(&dxc_command).step);
 
-    b.getInstallStep().dependOn(dxc_step);
+    install_content_step.step.dependOn(dxc_step);
 
     // Standard target options allows the person running `zig build` to choose
     // what target to build for. Here we do not override the defaults, which


### PR DESCRIPTION
Fixes #1

The step that installs the content directory must run after the shaders are generated.  However, the current version only says that the "global install step" depends on the shader generation.  Instead, we need to say that the step that specifically installs the shaders depends on shader generation.

NOTE: I think this same problem exists in the other samples

For more explanation, what's going on becomes clear when you look at the implementation for `installDirectory`:
```zig
    pub fn installDirectory(self: *Builder, options: InstallDirectoryOptions) void {
        self.getInstallStep().dependOn(&self.addInstallDirectory(options).step);
    }
```
This shows that when you add an `installDirectory` step, it does not add operations to the "install step", rather, it's an entirely new step that the global "install step" will depend on.  This makes it clear that adding another step like shader generation as a dependency of the global install step would have no order relationship with an `installDirectory` step.
