### PR TITLE
Add `comboFromEnum` function

### DIFF
--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -1487,7 +1487,7 @@ pub fn comboFromEnum(
         }
     };
 
-    var item = @intCast(@intFromEnum(current_item.*));
+    var item:i32 = @intCast(@intFromEnum(current_item.*));
 
     const result = combo(
         label,
@@ -1497,7 +1497,7 @@ pub fn comboFromEnum(
         }
     );
 
-    current_item.* = @enumFromInt(@TypeOf(current_item.*), item);
+    current_item.* = @enumFromInt(item);
 
     return result;
 }


### PR DESCRIPTION
Closes #353 

* wrapper around `combo` that uses comptime reflection to turn an enum's possibilities into options for a combo
* allows for making dropdowns that drive enums really easily, example:

```zig
    const FoodKinds = enum(i8) {
        banana = 0,
        taco,
        spaghetti,
    };

    var myEnum : FoodKinds = .banana;

    _ = zgui.comboFromEnum( "Food", &myEnum);
```

Makes this combobox:
![Screenshot 2023-07-24 at 10 32 50 AM](https://github.com/michal-z/zig-gamedev/assets/61017/72636a5f-e84f-4d24-946c-3e8b7cdabb95)

