### PR TITLE
Update all `build.zig`s to the latest Zig nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ We build game development ecosystem for [Zig programming language](https://zigla
 * Cross-platform [sample applications](#sample-applications-native-wgpu)
 * DirectX 12 [sample applications](#sample-applications-directx-12)
 
-Please note that Zig is still in development. Our [main](https://github.com/zig-gamedev/zig-gamedev/tree/main) branch tracks a periodically nominated version of the Zig compiler, this is **0.12.0-dev.1871+e426ae43a** currently, which can be downloaded using the links below.
+Please note that Zig is still in development. Our [main](https://github.com/zig-gamedev/zig-gamedev/tree/main) branch tracks a periodically nominated version of the Zig compiler, this is **0.12.0-dev.2139+e025ad7b4** currently, which can be downloaded using the links below.
 
 | OS/Arch         | Download link               |
 | --------------- | --------------------------- |
-| Windows x86_64  | [zig-windows-x86_64-0.12.0-dev.1871+e426ae43a.zip](https://ziglang.org/builds/zig-windows-x86_64-0.12.0-dev.1871+e426ae43a.zip) |
-| Linux x86_64    | [zig-linux-x86_64-0.12.0-dev.1871+e426ae43a.tar.xz](https://ziglang.org/builds/zig-linux-x86_64-0.12.0-dev.1871+e426ae43a.tar.xz) |
-| macOS x86_64    | [zig-macos-x86_64-0.12.0-dev.1871+e426ae43a.tar.xz](https://ziglang.org/builds/zig-macos-x86_64-0.12.0-dev.1871+e426ae43a.tar.xz) |
-| macOS aarch64   | [zig-macos-aarch64-0.12.0-dev.1871+e426ae43a.tar.xz](https://ziglang.org/builds/zig-macos-aarch64-0.12.0-dev.1871+e426ae43a.tar.xz) |
+| Windows x86_64  | [zig-windows-x86_64-0.12.0-dev.2139+e025ad7b4.zip](https://ziglang.org/builds/zig-windows-x86_64-0.12.0-dev.2139+e025ad7b4.zip) |
+| Linux x86_64    | [zig-linux-x86_64-0.12.0-dev.2139+e025ad7b4.tar.xz](https://ziglang.org/builds/zig-linux-x86_64-0.12.0-dev.2139+e025ad7b4.tar.xz) |
+| macOS x86_64    | [zig-macos-x86_64-0.12.0-dev.2139+e025ad7b4.tar.xz](https://ziglang.org/builds/zig-macos-x86_64-0.12.0-dev.2139+e025ad7b4.tar.xz) |
+| macOS aarch64   | [zig-macos-aarch64-0.12.0-dev.2139+e025ad7b4.tar.xz](https://ziglang.org/builds/zig-macos-aarch64-0.12.0-dev.2139+e025ad7b4.tar.xz) |
 
 If you need to use a more recent version of Zig, you may want to use our [unstable](https://github.com/zig-gamedev/zig-gamedev/tree/unstable) branch. But this is not generally recommended.
 

--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,7 @@
 const builtin = @import("builtin");
 const std = @import("std");
 
-pub const min_zig_version = std.SemanticVersion{ .major = 0, .minor = 12, .patch = 0, .pre = "dev.1871" };
+pub const min_zig_version = std.SemanticVersion{ .major = 0, .minor = 12, .patch = 0, .pre = "dev.2139" };
 
 pub fn build(b: *std.Build) void {
     //

--- a/experiments/genart/build.zig
+++ b/experiments/genart/build.zig
@@ -11,9 +11,9 @@ pub fn build(b: *std.Build, options: Options) void {
 }
 
 fn install(
-    b: *std.build.Builder,
+    b: *std.Build,
     optimize: std.builtin.Mode,
-    target: std.zig.CrossTarget,
+    target: std.Build.ResolvedTarget,
     comptime name: []const u8,
 ) void {
     const zsdl_pkg = @import("../../build.zig").zsdl_pkg;
@@ -27,16 +27,16 @@ fn install(
     const desc_size = comptime std.mem.indexOf(u8, &desc_name, "\x00").?;
 
     const xcommon = b.createModule(.{
-        .source_file = .{ .path = thisDir() ++ "/src/xcommon.zig" },
-        .dependencies = &.{
+        .root_source_file = .{ .path = thisDir() ++ "/src/xcommon.zig" },
+        .imports = &.{
             .{ .name = "zsdl", .module = zsdl_pkg.zsdl },
             .{ .name = "zopengl", .module = zopengl_pkg.zopengl },
             .{ .name = "zstbi", .module = zstbi_pkg.zstbi },
         },
     });
     const ximpl = b.createModule(.{
-        .source_file = .{ .path = thisDir() ++ "/src/" ++ name ++ ".zig" },
-        .dependencies = &.{
+        .root_source_file = .{ .path = thisDir() ++ "/src/" ++ name ++ ".zig" },
+        .imports = &.{
             .{ .name = "zsdl", .module = zsdl_pkg.zsdl },
             .{ .name = "zopengl", .module = zopengl_pkg.zopengl },
             .{ .name = "zmath", .module = zmath_pkg.zmath },
@@ -51,8 +51,8 @@ fn install(
         .optimize = optimize,
     });
     exe.rdynamic = true;
-    exe.addModule("xcommon", xcommon);
-    exe.addModule("ximpl", ximpl);
+    exe.root_module.addImport("xcommon", xcommon);
+    exe.root_module.addImport("ximpl", ximpl);
     zsdl_pkg.link(exe);
     zopengl_pkg.link(exe);
     zstbi_pkg.link(exe);

--- a/libs/zd3d12/build.zig
+++ b/libs/zd3d12/build.zig
@@ -19,15 +19,15 @@ pub const Package = struct {
     zd3d12: *std.Build.Module,
     zd3d12_options: *std.Build.Module,
 
-    pub fn link(pkg: Package, exe: *std.Build.CompileStep) void {
-        exe.addModule("zd3d12", pkg.zd3d12);
-        exe.addModule("zd3d12_options", pkg.zd3d12_options);
+    pub fn link(pkg: Package, exe: *std.Build.Step.Compile) void {
+        exe.root_module.addImport("zd3d12", pkg.zd3d12);
+        exe.root_module.addImport("zd3d12_options", pkg.zd3d12_options);
     }
 };
 
 pub fn package(
     b: *std.Build,
-    _: std.zig.CrossTarget,
+    _: std.Build.ResolvedTarget,
     _: std.builtin.Mode,
     args: struct {
         options: Options = .{},
@@ -43,8 +43,8 @@ pub fn package(
     const zd3d12_options = step.createModule();
 
     const zd3d12 = b.addModule("zd3d12", .{
-        .source_file = .{ .path = thisDir() ++ "/src/zd3d12.zig" },
-        .dependencies = &.{
+        .root_source_file = .{ .path = thisDir() ++ "/src/zd3d12.zig" },
+        .imports = &.{
             .{ .name = "zd3d12_options", .module = zd3d12_options },
             .{ .name = "zwin32", .module = args.deps.zwin32 },
         },

--- a/libs/zgpu/build.zig
+++ b/libs/zgpu/build.zig
@@ -33,68 +33,76 @@ pub const Package = struct {
     zgpu: *std.Build.Module,
     zgpu_options: *std.Build.Module,
 
-    pub fn link(pkg: Package, exe: *std.Build.CompileStep) void {
-        const target = (std.zig.system.NativeTargetInfo.detect(exe.target) catch unreachable).target;
+    pub fn link(pkg: Package, exe: *std.Build.Step.Compile) void {
+        const target = exe.rootModuleTarget();
 
-        exe.addModule("zgpu", pkg.zgpu);
-        exe.addModule("zgpu_options", pkg.zgpu_options);
+        exe.root_module.addImport("zgpu", pkg.zgpu);
+        exe.root_module.addImport("zgpu_options", pkg.zgpu_options);
 
         const b = exe.step.owner;
 
         switch (target.os.tag) {
             .windows => {
                 const dawn_dep = b.dependency("dawn_x86_64_windows_gnu", .{});
-                exe.addLibraryPath(.{ .path = dawn_dep.builder.build_root.path.? });
-                exe.addLibraryPath(.{ .path = thisDir() ++ "/../system-sdk/windows/lib/x86_64-windows-gnu" });
+                exe.root_module.addLibraryPath(.{ .path = dawn_dep.builder.build_root.path.? });
+                exe.root_module.addLibraryPath(.{
+                    .path = thisDir() ++ "/../system-sdk/windows/lib/x86_64-windows-gnu",
+                });
 
-                exe.linkSystemLibraryName("ole32");
-                exe.linkSystemLibraryName("dxguid");
+                exe.root_module.linkSystemLibrary("ole32", .{});
+                exe.root_module.linkSystemLibrary("dxguid", .{});
             },
             .linux => {
                 if (target.cpu.arch.isX86()) {
                     const dawn_dep = b.dependency("dawn_x86_64_linux_gnu", .{});
-                    exe.addLibraryPath(.{ .path = dawn_dep.builder.build_root.path.? });
+                    exe.root_module.addLibraryPath(.{ .path = dawn_dep.builder.build_root.path.? });
                 } else {
                     const dawn_dep = b.dependency("dawn_aarch64_linux_gnu", .{});
-                    exe.addLibraryPath(.{ .path = dawn_dep.builder.build_root.path.? });
+                    exe.root_module.addLibraryPath(.{ .path = dawn_dep.builder.build_root.path.? });
                 }
             },
             .macos => {
-                exe.addFrameworkPath(.{ .path = thisDir() ++ "/../system-sdk/macos12/System/Library/Frameworks" });
-                exe.addSystemIncludePath(.{ .path = thisDir() ++ "/../system-sdk/macos12/usr/include" });
-                exe.addLibraryPath(.{ .path = thisDir() ++ "/../system-sdk/macos12/usr/lib" });
+                exe.root_module.addFrameworkPath(.{
+                    .path = thisDir() ++ "/../system-sdk/macos12/System/Library/Frameworks",
+                });
+                exe.root_module.addSystemIncludePath(.{
+                    .path = thisDir() ++ "/../system-sdk/macos12/usr/include",
+                });
+                exe.root_module.addLibraryPath(.{
+                    .path = thisDir() ++ "/../system-sdk/macos12/usr/lib",
+                });
 
                 if (target.cpu.arch.isX86()) {
                     const dawn_dep = b.dependency("dawn_x86_64_macos", .{});
-                    exe.addLibraryPath(.{ .path = dawn_dep.builder.build_root.path.? });
+                    exe.root_module.addLibraryPath(.{ .path = dawn_dep.builder.build_root.path.? });
                 } else {
                     const dawn_dep = b.dependency("dawn_aarch64_macos", .{});
-                    exe.addLibraryPath(.{ .path = dawn_dep.builder.build_root.path.? });
+                    exe.root_module.addLibraryPath(.{ .path = dawn_dep.builder.build_root.path.? });
                 }
 
-                exe.linkSystemLibraryName("objc");
-                exe.linkFramework("Metal");
-                exe.linkFramework("CoreGraphics");
-                exe.linkFramework("Foundation");
-                exe.linkFramework("IOKit");
-                exe.linkFramework("IOSurface");
-                exe.linkFramework("QuartzCore");
+                exe.root_module.linkSystemLibrary("objc", .{});
+                exe.root_module.linkFramework("Metal", .{});
+                exe.root_module.linkFramework("CoreGraphics", .{});
+                exe.root_module.linkFramework("Foundation", .{});
+                exe.root_module.linkFramework("IOKit", .{});
+                exe.root_module.linkFramework("IOSurface", .{});
+                exe.root_module.linkFramework("QuartzCore", .{});
             },
             else => unreachable,
         }
 
-        exe.linkSystemLibraryName("dawn");
-        exe.linkLibC();
-        exe.linkLibCpp();
+        exe.root_module.linkSystemLibrary("dawn", .{});
+        exe.root_module.link_libc = true;
+        exe.root_module.link_libcpp = true;
 
-        exe.addIncludePath(.{ .path = thisDir() ++ "/libs/dawn/include" });
-        exe.addIncludePath(.{ .path = thisDir() ++ "/src" });
+        exe.root_module.addIncludePath(.{ .path = thisDir() ++ "/libs/dawn/include" });
+        exe.root_module.addIncludePath(.{ .path = thisDir() ++ "/src" });
 
-        exe.addCSourceFile(.{
+        exe.root_module.addCSourceFile(.{
             .file = .{ .path = thisDir() ++ "/src/dawn.cpp" },
             .flags = &.{ "-std=c++17", "-fno-sanitize=undefined" },
         });
-        exe.addCSourceFile(.{
+        exe.root_module.addCSourceFile(.{
             .file = .{ .path = thisDir() ++ "/src/dawn_proc.c" },
             .flags = &.{"-fno-sanitize=undefined"},
         });
@@ -103,7 +111,7 @@ pub const Package = struct {
 
 pub fn package(
     b: *std.Build,
-    _: std.zig.CrossTarget,
+    _: std.Build.ResolvedTarget,
     _: std.builtin.Mode,
     args: struct {
         options: Options = .{},
@@ -129,8 +137,8 @@ pub fn package(
     const zgpu_options = step.createModule();
 
     const zgpu = b.addModule("zgpu", .{
-        .source_file = .{ .path = thisDir() ++ "/src/zgpu.zig" },
-        .dependencies = &.{
+        .root_source_file = .{ .path = thisDir() ++ "/src/zgpu.zig" },
+        .imports = &.{
             .{ .name = "zgpu_options", .module = zgpu_options },
             .{ .name = "zglfw", .module = args.deps.zglfw },
             .{ .name = "zpool", .module = args.deps.zpool },

--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -1473,7 +1473,7 @@ pub fn comboFromEnum(
         const item_type = @typeInfo(@TypeOf(current_item.*));
         switch (item_type) {
             .Enum => |e| {
-                comptime var str: [:0]const u8 = "";
+                var str: [:0]const u8 = "";
 
                 for (e.fields) |f| {
                     str = str ++ f.name ++ "\x00";

--- a/libs/zjobs/build.zig
+++ b/libs/zjobs/build.zig
@@ -3,19 +3,19 @@ const std = @import("std");
 pub const Package = struct {
     zjobs: *std.Build.Module,
 
-    pub fn link(pkg: Package, exe: *std.Build.CompileStep) void {
-        exe.addModule("zjobs", pkg.zjobs);
+    pub fn link(pkg: Package, exe: *std.Build.Step.Compile) void {
+        exe.root_module.addImport("zjobs", pkg.zjobs);
     }
 };
 
 pub fn package(
     b: *std.Build,
-    _: std.zig.CrossTarget,
+    _: std.Build.ResolvedTarget,
     _: std.builtin.Mode,
     _: struct {},
 ) Package {
     const zjobs = b.addModule("zjobs", .{
-        .source_file = .{ .path = thisDir() ++ "/src/zjobs.zig" },
+        .root_source_file = .{ .path = thisDir() ++ "/src/zjobs.zig" },
     });
     return .{ .zjobs = zjobs };
 }
@@ -33,7 +33,7 @@ pub fn build(b: *std.Build) void {
 pub fn runTests(
     b: *std.Build,
     optimize: std.builtin.Mode,
-    target: std.zig.CrossTarget,
+    target: std.Build.ResolvedTarget,
 ) *std.Build.Step {
     const tests = b.addTest(.{
         .name = "zjobs-tests",

--- a/libs/zmesh/build.zig
+++ b/libs/zmesh/build.zig
@@ -9,18 +9,18 @@ pub const Package = struct {
     options: Options,
     zmesh: *std.Build.Module,
     zmesh_options: *std.Build.Module,
-    zmesh_c_cpp: *std.Build.CompileStep,
+    zmesh_c_cpp: *std.Build.Step.Compile,
 
-    pub fn link(pkg: Package, exe: *std.Build.CompileStep) void {
-        exe.linkLibrary(pkg.zmesh_c_cpp);
-        exe.addModule("zmesh", pkg.zmesh);
-        exe.addModule("zmesh_options", pkg.zmesh_options);
+    pub fn link(pkg: Package, exe: *std.Build.Step.Compile) void {
+        exe.root_module.linkLibrary(pkg.zmesh_c_cpp);
+        exe.root_module.addImport("zmesh", pkg.zmesh);
+        exe.root_module.addImport("zmesh_options", pkg.zmesh_options);
     }
 };
 
 pub fn package(
     b: *std.Build,
-    target: std.zig.CrossTarget,
+    target: std.Build.ResolvedTarget,
     optimize: std.builtin.Mode,
     args: struct {
         options: Options = .{},
@@ -33,8 +33,8 @@ pub fn package(
     const zmesh_options = step.createModule();
 
     const zmesh = b.addModule("zmesh", .{
-        .source_file = .{ .path = thisDir() ++ "/src/main.zig" },
-        .dependencies = &.{
+        .root_source_file = .{ .path = thisDir() ++ "/src/main.zig" },
+        .imports = &.{
             .{ .name = "zmesh_options", .module = zmesh_options },
         },
     });
@@ -46,7 +46,7 @@ pub fn package(
             .optimize = optimize,
         });
 
-        if (target.isWindows()) {
+        if (target.result.os.tag == .windows) {
             lib.defineCMacro("CGLTF_API", "__declspec(dllexport)");
             lib.defineCMacro("MESHOPTIMIZER_API", "__declspec(dllexport)");
             lib.defineCMacro("ZMESH_API", "__declspec(dllexport)");
@@ -59,23 +59,22 @@ pub fn package(
         .optimize = optimize,
     });
 
-    const abi = (std.zig.system.NativeTargetInfo.detect(target) catch unreachable).target.abi;
-    zmesh_c_cpp.linkLibC();
-    if (abi != .msvc)
-        zmesh_c_cpp.linkLibCpp();
+    zmesh_c_cpp.root_module.link_libc = true;
+    if (target.result.abi != .msvc)
+        zmesh_c_cpp.root_module.link_libcpp = true;
 
     const par_shapes_t = if (args.options.shape_use_32bit_indices)
         "-DPAR_SHAPES_T=uint32_t"
     else
         "-DPAR_SHAPES_T=uint16_t";
 
-    zmesh_c_cpp.addIncludePath(.{ .path = thisDir() ++ "/libs/par_shapes" });
-    zmesh_c_cpp.addCSourceFile(.{
+    zmesh_c_cpp.root_module.addIncludePath(.{ .path = thisDir() ++ "/libs/par_shapes" });
+    zmesh_c_cpp.root_module.addCSourceFile(.{
         .file = .{ .path = thisDir() ++ "/libs/par_shapes/par_shapes.c" },
         .flags = &.{ "-std=c99", "-fno-sanitize=undefined", par_shapes_t },
     });
 
-    zmesh_c_cpp.addCSourceFiles(.{
+    zmesh_c_cpp.root_module.addCSourceFiles(.{
         .files = &.{
             thisDir() ++ "/libs/meshoptimizer/clusterizer.cpp",
             thisDir() ++ "/libs/meshoptimizer/indexgenerator.cpp",
@@ -90,8 +89,8 @@ pub fn package(
         },
         .flags = &.{""},
     });
-    zmesh_c_cpp.addIncludePath(.{ .path = thisDir() ++ "/libs/cgltf" });
-    zmesh_c_cpp.addCSourceFile(.{
+    zmesh_c_cpp.root_module.addIncludePath(.{ .path = thisDir() ++ "/libs/cgltf" });
+    zmesh_c_cpp.root_module.addCSourceFile(.{
         .file = .{ .path = thisDir() ++ "/libs/cgltf/cgltf.c" },
         .flags = &.{"-std=c99"},
     });
@@ -122,7 +121,7 @@ pub fn build(b: *std.Build) void {
 pub fn runTests(
     b: *std.Build,
     optimize: std.builtin.Mode,
-    target: std.zig.CrossTarget,
+    target: std.Build.ResolvedTarget,
 ) *std.Build.Step {
     const tests = b.addTest(.{
         .name = "zmesh-tests",

--- a/libs/zopengl/build.zig
+++ b/libs/zopengl/build.zig
@@ -14,14 +14,14 @@ pub const Package = struct {
     zopengl: *std.Build.Module,
     zopengl_options: *std.Build.Module,
 
-    pub fn link(pkg: Package, exe: *std.Build.CompileStep) void {
-        exe.addModule("zopengl", pkg.zopengl);
+    pub fn link(pkg: Package, exe: *std.Build.Step.Compile) void {
+        exe.root_module.addImport("zopengl", pkg.zopengl);
     }
 };
 
 pub fn package(
     b: *std.Build,
-    _: std.zig.CrossTarget,
+    _: std.Build.ResolvedTarget,
     _: std.builtin.Mode,
     args: struct {
         options: Options = .{
@@ -38,8 +38,8 @@ pub fn package(
     const options = options_step.createModule();
 
     const zopengl = b.addModule("zopengl", .{
-        .source_file = .{ .path = thisDir() ++ "/src/zopengl.zig" },
-        .dependencies = &.{
+        .root_source_file = .{ .path = thisDir() ++ "/src/zopengl.zig" },
+        .imports = &.{
             .{ .name = "zopengl_options", .module = options },
         },
     });
@@ -54,7 +54,7 @@ pub fn package(
 pub fn runTests(
     b: *std.Build,
     optimize: std.builtin.Mode,
-    target: std.zig.CrossTarget,
+    target: std.Build.ResolvedTarget,
 ) *std.Build.Step {
     const tests = b.addTest(.{
         .name = "zopengl-tests",
@@ -67,7 +67,7 @@ pub fn runTests(
             .api = .wrapper,
         },
     });
-    tests.addModule("zopengl_options", zopengl_pkg.zopengl_options);
+    tests.root_module.addImport("zopengl_options", zopengl_pkg.zopengl_options);
     zopengl_pkg.link(tests);
 
     return &b.addRunArtifact(tests).step;

--- a/libs/zphysics/build.zig
+++ b/libs/zphysics/build.zig
@@ -48,6 +48,10 @@ pub fn package(
         },
     });
 
+    // Below necessary to avoid missing cInclude errors in project `build.zig`
+    zphysics.addIncludePath(.{ .path = thisDir() ++ "/libs" });
+    zphysics.addIncludePath(.{ .path = thisDir() ++ "/libs/JoltC" });
+
     const zphysics_c_cpp = b.addStaticLibrary(.{
         .name = "zphysics",
         .target = target,

--- a/libs/zpix/build.zig
+++ b/libs/zpix/build.zig
@@ -9,15 +9,15 @@ pub const Package = struct {
     zpix: *std.Build.Module,
     zpix_options: *std.Build.Module,
 
-    pub fn link(pkg: Package, exe: *std.Build.CompileStep) void {
-        exe.addModule("zpix", pkg.zpix);
-        exe.addModule("zpix_options", pkg.zpix_options);
+    pub fn link(pkg: Package, exe: *std.Build.Step.Compile) void {
+        exe.root_module.addImport("zpix", pkg.zpix);
+        exe.root_module.addImport("zpix_options", pkg.zpix_options);
     }
 };
 
 pub fn package(
     b: *std.Build,
-    _: std.zig.CrossTarget,
+    _: std.Build.ResolvedTarget,
     _: std.builtin.Mode,
     args: struct {
         options: Options = .{},
@@ -30,8 +30,8 @@ pub fn package(
     const zpix_options = step.createModule();
 
     const zpix = b.createModule(.{
-        .source_file = .{ .path = thisDir() ++ "/src/zpix.zig" },
-        .dependencies = &.{
+        .root_source_file = .{ .path = thisDir() ++ "/src/zpix.zig" },
+        .imports = &.{
             .{ .name = "zpix_options", .module = zpix_options },
             .{ .name = "zwin32", .module = args.deps.zwin32 },
         },

--- a/libs/zpool/build.zig
+++ b/libs/zpool/build.zig
@@ -3,19 +3,19 @@ const std = @import("std");
 pub const Package = struct {
     zpool: *std.Build.Module,
 
-    pub fn link(pkg: Package, exe: *std.Build.CompileStep) void {
-        exe.addModule("zpool", pkg.zpool);
+    pub fn link(pkg: Package, exe: *std.Build.Step.Compile) void {
+        exe.root_module.addImport("zpool", pkg.zpool);
     }
 };
 
 pub fn package(
     b: *std.Build,
-    _: std.zig.CrossTarget,
+    _: std.Build.ResolvedTarget,
     _: std.builtin.Mode,
     _: struct {},
 ) Package {
     const zpool = b.addModule("zpool", .{
-        .source_file = .{ .path = thisDir() ++ "/src/main.zig" },
+        .root_source_file = .{ .path = thisDir() ++ "/src/main.zig" },
     });
     return .{ .zpool = zpool };
 }
@@ -33,7 +33,7 @@ pub fn build(b: *std.Build) void {
 pub fn runTests(
     b: *std.Build,
     optimize: std.builtin.Mode,
-    target: std.zig.CrossTarget,
+    target: std.Build.ResolvedTarget,
 ) *std.Build.Step {
     const tests = b.addTest(.{
         .name = "zpool-tests",

--- a/libs/zsdl/build.zig
+++ b/libs/zsdl/build.zig
@@ -70,7 +70,7 @@ pub const Package = struct {
                 }
             },
             .macos => {
-                exe.root_module.addRPath(.{ .path = "@executable_path/Frameworks" });
+               exe.root_module.addRPathSpecial("@executable_path/Frameworks");
 
                 exe.root_module.addFrameworkPath(.{
                     .path = thisDir() ++ "/libs/macos/Frameworks",

--- a/libs/ztracy/build.zig
+++ b/libs/ztracy/build.zig
@@ -53,6 +53,8 @@ pub fn package(
             .{ .name = "ztracy_options", .module = ztracy_options },
         },
     });
+    // Below necessary to avoid missing cInclude in project `build.zig`
+    ztracy.addIncludePath(.{ .path = thisDir() ++ "/libs/tracy/tracy" });
 
     const ztracy_c_cpp = if (args.options.enable_ztracy) ztracy_c_cpp: {
         const enable_fibers = if (args.options.enable_fibers) "-DTRACY_FIBERS" else "";

--- a/libs/zwin32/build.zig
+++ b/libs/zwin32/build.zig
@@ -13,8 +13,8 @@ pub const Package = struct {
     install_xaudio2: *std.Build.Step,
     install_directml: *std.Build.Step,
 
-    pub fn link(pkg: Package, exe: *std.Build.CompileStep, libs: Libs) void {
-        exe.addModule("zwin32", pkg.zwin32);
+    pub fn link(pkg: Package, exe: *std.Build.Step.Compile, libs: Libs) void {
+        exe.root_module.addImport("zwin32", pkg.zwin32);
         if (libs.d3d12) exe.step.dependOn(pkg.install_d3d12);
         if (libs.xaudio2) exe.step.dependOn(pkg.install_xaudio2);
         if (libs.directml) exe.step.dependOn(pkg.install_directml);
@@ -23,18 +23,30 @@ pub const Package = struct {
 
 pub fn package(
     b: *std.Build,
-    _: std.zig.CrossTarget,
+    _: std.Build.ResolvedTarget,
     _: std.builtin.Mode,
     _: struct {},
 ) Package {
     const install_d3d12 = b.allocator.create(std.Build.Step) catch @panic("OOM");
-    install_d3d12.* = std.Build.Step.init(.{ .id = .custom, .name = "zwin32-install-d3d12", .owner = b });
+    install_d3d12.* = std.Build.Step.init(.{
+        .id = .custom,
+        .name = "zwin32-install-d3d12",
+        .owner = b,
+    });
 
     const install_xaudio2 = b.allocator.create(std.Build.Step) catch @panic("OOM");
-    install_xaudio2.* = std.Build.Step.init(.{ .id = .custom, .name = "zwin32-install-xaudio2", .owner = b });
+    install_xaudio2.* = std.Build.Step.init(.{
+        .id = .custom,
+        .name = "zwin32-install-xaudio2",
+        .owner = b,
+    });
 
     const install_directml = b.allocator.create(std.Build.Step) catch @panic("OOM");
-    install_directml.* = std.Build.Step.init(.{ .id = .custom, .name = "zwin32-install-directml", .owner = b });
+    install_directml.* = std.Build.Step.init(.{
+        .id = .custom,
+        .name = "zwin32-install-directml",
+        .owner = b,
+    });
 
     install_d3d12.dependOn(
         &b.addInstallFile(
@@ -71,7 +83,7 @@ pub fn package(
 
     return .{
         .zwin32 = b.addModule("zwin32", .{
-            .source_file = .{ .path = thisDir() ++ "/src/zwin32.zig" },
+            .root_source_file = .{ .path = thisDir() ++ "/src/zwin32.zig" },
         }),
         .install_d3d12 = install_d3d12,
         .install_xaudio2 = install_xaudio2,

--- a/libs/zxaudio2/build.zig
+++ b/libs/zxaudio2/build.zig
@@ -9,15 +9,15 @@ pub const Package = struct {
     zxaudio2: *std.Build.Module,
     zxaudio2_options: *std.Build.Module,
 
-    pub fn link(pkg: Package, exe: *std.Build.CompileStep) void {
-        exe.addModule("zxaudio2", pkg.zxaudio2);
-        exe.addModule("zxaudio2_options", pkg.zxaudio2_options);
+    pub fn link(pkg: Package, exe: *std.Build.Step.Compile) void {
+        exe.root_module.addImport("zxaudio2", pkg.zxaudio2);
+        exe.root_module.addImport("zxaudio2_options", pkg.zxaudio2_options);
     }
 };
 
 pub fn package(
     b: *std.Build,
-    _: std.zig.CrossTarget,
+    _: std.Build.ResolvedTarget,
     _: std.builtin.Mode,
     args: struct {
         options: Options = .{},
@@ -30,8 +30,8 @@ pub fn package(
     const zxaudio2_options = step.createModule();
 
     const zxaudio2 = b.addModule("zxaudio2", .{
-        .source_file = .{ .path = thisDir() ++ "/src/zxaudio2.zig" },
-        .dependencies = &.{
+        .root_source_file = .{ .path = thisDir() ++ "/src/zxaudio2.zig" },
+        .imports = &.{
             .{ .name = "zxaudio2_options", .module = zxaudio2_options },
             .{ .name = "zwin32", .module = args.deps.zwin32 },
         },

--- a/samples/audio_experiments/build.zig
+++ b/samples/audio_experiments/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const Options = @import("../../build.zig").Options;
 const content_dir = "audio_experiments_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "audio_experiments",
         .root_source_file = .{ .path = thisDir() ++ "/src/audio_experiments.zig" },
@@ -24,7 +24,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zxaudio2_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const dxc_step = buildShaders(b);

--- a/samples/audio_experiments_wgpu/build.zig
+++ b/samples/audio_experiments_wgpu/build.zig
@@ -5,7 +5,7 @@ const Options = @import("../../build.zig").Options;
 const demo_name = "audio_experiments_wgpu";
 const content_dir = demo_name ++ "_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = demo_name,
         .root_source_file = .{ .path = thisDir() ++ "/src/" ++ demo_name ++ ".zig" },
@@ -26,7 +26,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zmath_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const install_content_step = b.addInstallDirectory(.{

--- a/samples/audio_playback_test/build.zig
+++ b/samples/audio_playback_test/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const Options = @import("../../build.zig").Options;
 const content_dir = "audio_playback_test_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "audio_playback_test",
         .root_source_file = .{ .path = thisDir() ++ "/src/audio_playback_test.zig" },
@@ -20,7 +20,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zd3d12_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const dxc_step = buildShaders(b);

--- a/samples/bindless/build.zig
+++ b/samples/bindless/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const Options = @import("../../build.zig").Options;
 const content_dir = "bindless_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "bindless",
         .root_source_file = .{ .path = thisDir() ++ "/src/bindless.zig" },
@@ -24,7 +24,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zd3d12_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const dxc_step = buildShaders(b);

--- a/samples/bullet_physics_test_wgpu/build.zig
+++ b/samples/bullet_physics_test_wgpu/build.zig
@@ -5,7 +5,7 @@ const Options = @import("../../build.zig").Options;
 const demo_name = "bullet_physics_test_wgpu";
 const content_dir = demo_name ++ "_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = demo_name,
         .root_source_file = .{ .path = thisDir() ++ "/src/" ++ demo_name ++ ".zig" },
@@ -28,7 +28,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zmath_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const install_content_step = b.addInstallDirectory(.{

--- a/samples/directml_convolution_test/build.zig
+++ b/samples/directml_convolution_test/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const Options = @import("../../build.zig").Options;
 const content_dir = "directml_convolution_test_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "directml_convolution_test",
         .root_source_file = .{ .path = thisDir() ++ "/src/directml_convolution_test.zig" },
@@ -20,7 +20,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zd3d12_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const dxc_step = buildShaders(b);

--- a/samples/gamepad_wgpu/build.zig
+++ b/samples/gamepad_wgpu/build.zig
@@ -5,7 +5,7 @@ const Options = @import("../../build.zig").Options;
 const demo_name = "gamepad_wgpu";
 const content_dir = demo_name ++ "_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = demo_name,
         .root_source_file = .{ .path = thisDir() ++ "/src/" ++ demo_name ++ ".zig" },
@@ -24,7 +24,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zmath_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const install_content_step = b.addInstallDirectory(.{

--- a/samples/gui_test_wgpu/build.zig
+++ b/samples/gui_test_wgpu/build.zig
@@ -5,7 +5,7 @@ const Options = @import("../../build.zig").Options;
 const demo_name = "gui_test_wgpu";
 const content_dir = demo_name ++ "_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = demo_name,
         .root_source_file = .{ .path = thisDir() ++ "/src/" ++ demo_name ++ ".zig" },
@@ -26,7 +26,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zmath_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const install_content_step = b.addInstallDirectory(.{

--- a/samples/instanced_pills_wgpu/build.zig
+++ b/samples/instanced_pills_wgpu/build.zig
@@ -6,7 +6,7 @@ const demo_name = "instanced_pills_wgpu";
 const demo_filename = "instanced_pills_wgpu";
 const content_dir = demo_name ++ "_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = demo_name,
         .root_source_file = .{ .path = thisDir() ++ "/src/" ++ demo_filename ++ ".zig" },
@@ -25,7 +25,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zmath_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const install_content_step = b.addInstallDirectory(.{

--- a/samples/layers_wgpu/build.zig
+++ b/samples/layers_wgpu/build.zig
@@ -5,7 +5,7 @@ const Options = @import("../../build.zig").Options;
 const demo_name = "layers_wgpu";
 const content_dir = demo_name ++ "_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = demo_name,
         .root_source_file = .{ .path = thisDir() ++ "/src/" ++ demo_name ++ ".zig" },
@@ -24,7 +24,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zmath_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const install_content_step = b.addInstallDirectory(.{

--- a/samples/mesh_shader_test/build.zig
+++ b/samples/mesh_shader_test/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const Options = @import("../../build.zig").Options;
 const content_dir = "mesh_shader_test_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "mesh_shader_test",
         .root_source_file = .{ .path = thisDir() ++ "/src/mesh_shader_test.zig" },
@@ -22,7 +22,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zd3d12_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const dxc_step = buildShaders(b);

--- a/samples/minimal_d3d12/build.zig
+++ b/samples/minimal_d3d12/build.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 const Options = @import("../../build.zig").Options;
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "minimal_d3d12",
         .root_source_file = .{ .path = thisDir() ++ "/src/minimal_d3d12.zig" },

--- a/samples/minimal_glfw_gl/build.zig
+++ b/samples/minimal_glfw_gl/build.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 const Options = @import("../../build.zig").Options;
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "minimal_glfw_gl",
         .root_source_file = .{ .path = thisDir() ++ "/src/minimal_glfw_gl.zig" },

--- a/samples/minimal_sdl_gl/build.zig
+++ b/samples/minimal_sdl_gl/build.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 const Options = @import("../../build.zig").Options;
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "minimal_sdl_gl",
         .root_source_file = .{ .path = thisDir() ++ "/src/minimal_sdl_gl.zig" },

--- a/samples/minimal_zgpu_zgui/build.zig
+++ b/samples/minimal_zgpu_zgui/build.zig
@@ -5,7 +5,7 @@ const Options = @import("../../build.zig").Options;
 const demo_name = "minimal_zgpu_zgui";
 const content_dir = demo_name ++ "_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = demo_name,
         .root_source_file = .{ .path = thisDir() ++ "/src/" ++ demo_name ++ ".zig" },
@@ -22,7 +22,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zglfw_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const install_content_step = b.addInstallDirectory(.{

--- a/samples/minimal_zgui_glfw_gl/build.zig
+++ b/samples/minimal_zgui_glfw_gl/build.zig
@@ -5,7 +5,7 @@ const Options = @import("../../build.zig").Options;
 const demo_name = "minimal_zgui_glfw_gl";
 const content_dir = demo_name ++ "_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = demo_name,
         .root_source_file = .{ .path = thisDir() ++ "/src/" ++ demo_name ++ ".zig" },
@@ -22,7 +22,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zglfw_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const install_content_step = b.addInstallDirectory(.{

--- a/samples/monolith/build.zig
+++ b/samples/monolith/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const Options = @import("../../build.zig").Options;
 const content_dir = "monolith_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "monolith",
         .root_source_file = .{ .path = thisDir() ++ "/src/monolith.zig" },
@@ -33,7 +33,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zphysics_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const install_content_step = b.addInstallDirectory(.{

--- a/samples/physically_based_rendering_wgpu/build.zig
+++ b/samples/physically_based_rendering_wgpu/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const Options = @import("../../build.zig").Options;
 const content_dir = "physically_based_rendering_wgpu_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "physically_based_rendering_wgpu",
         .root_source_file = .{ .path = thisDir() ++ "/src/physically_based_rendering_wgpu.zig" },
@@ -26,7 +26,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zmath_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const install_content_step = b.addInstallDirectory(.{

--- a/samples/physics_test_wgpu/build.zig
+++ b/samples/physics_test_wgpu/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const Options = @import("../../build.zig").Options;
 const content_dir = "physics_test_wgpu_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "physics_test_wgpu",
         .root_source_file = .{ .path = thisDir() ++ "/src/physics_test_wgpu.zig" },
@@ -26,7 +26,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zphysics_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const install_content_step = b.addInstallDirectory(.{

--- a/samples/procedural_mesh_wgpu/build.zig
+++ b/samples/procedural_mesh_wgpu/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const Options = @import("../../build.zig").Options;
 const content_dir = "procedural_mesh_wgpu_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "procedural_mesh_wgpu",
         .root_source_file = .{ .path = thisDir() ++ "/src/procedural_mesh_wgpu.zig" },
@@ -28,7 +28,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zmath_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const install_content_step = b.addInstallDirectory(.{

--- a/samples/rasterization/build.zig
+++ b/samples/rasterization/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const Options = @import("../../build.zig").Options;
 const content_dir = "rasterization_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "rasterization",
         .root_source_file = .{ .path = thisDir() ++ "/src/rasterization.zig" },
@@ -24,7 +24,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zd3d12_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const dxc_step = buildShaders(b);

--- a/samples/simple_raytracer/build.zig
+++ b/samples/simple_raytracer/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const Options = @import("../../build.zig").Options;
 const content_dir = "simple_raytracer_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "simple_raytracer",
         .root_source_file = .{ .path = thisDir() ++ "/src/simple_raytracer.zig" },
@@ -22,7 +22,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zd3d12_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const dxc_step = buildShaders(b);

--- a/samples/textured_quad/build.zig
+++ b/samples/textured_quad/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const Options = @import("../../build.zig").Options;
 const content_dir = "textured_quad_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "textured_quad",
         .root_source_file = .{ .path = thisDir() ++ "/src/textured_quad.zig" },
@@ -20,7 +20,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zd3d12_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const dxc_step = buildShaders(b);

--- a/samples/textured_quad_wgpu/build.zig
+++ b/samples/textured_quad_wgpu/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const Options = @import("../../build.zig").Options;
 const content_dir = "textured_quad_wgpu_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "textured_quad_wgpu",
         .root_source_file = .{ .path = thisDir() ++ "/src/textured_quad_wgpu.zig" },
@@ -24,7 +24,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zmath_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const install_content_step = b.addInstallDirectory(.{

--- a/samples/triangle/build.zig
+++ b/samples/triangle/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const Options = @import("../../build.zig").Options;
 const content_dir = "triangle_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "triangle",
         .root_source_file = .{ .path = thisDir() ++ "/src/triangle.zig" },
@@ -20,7 +20,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     common_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const dxc_step = buildShaders(b);

--- a/samples/triangle_wgpu/build.zig
+++ b/samples/triangle_wgpu/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const Options = @import("../../build.zig").Options;
 const content_dir = "triangle_wgpu_content/";
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "triangle_wgpu",
         .root_source_file = .{ .path = thisDir() ++ "/src/triangle_wgpu.zig" },
@@ -22,7 +22,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
     zmath_pkg.link(exe);
 
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     const install_content_step = b.addInstallDirectory(.{

--- a/samples/vector_graphics_test/build.zig
+++ b/samples/vector_graphics_test/build.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 const Options = @import("../../build.zig").Options;
 
-pub fn build(b: *std.Build, options: Options) *std.Build.CompileStep {
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "vector_graphics_test",
         .root_source_file = .{ .path = thisDir() ++ "/src/vector_graphics_test.zig" },


### PR DESCRIPTION
Currently running into a few `XXX.h` missing `cInclude` issues (seems to be okay when running each lib's individual `build.zig` (even `zig build test`), but problematic when building from root `build.zig`). Still WIP, but more eyes would be appreciated. 