### PR TITLE
zmath: skip failing Mac tests only on Apple Silicon

### DIFF
--- a/libs/zmath/src/zmath.zig
+++ b/libs/zmath/src/zmath.zig
@@ -792,7 +792,7 @@ pub inline fn min(v0: anytype, v1: anytype) @TypeOf(v0, v1) {
 }
 test "zmath.min" {
     // Calling math.inf causes test to fail!
-    if (builtin.target.os.tag == .macos) return error.SkipZigTest;
+    if (builtin.target.os.tag == .macos and builtin.target.cpu.arch == .aarch64) return error.SkipZigTest;
     {
         const v0 = f32x4(1.0, 3.0, 2.0, 7.0);
         const v1 = f32x4(2.0, 1.0, 4.0, math.inf(f32));
@@ -836,7 +836,7 @@ pub inline fn max(v0: anytype, v1: anytype) @TypeOf(v0, v1) {
 }
 test "zmath.max" {
     // Calling math.inf causes test to fail!
-    if (builtin.target.os.tag == .macos) return error.SkipZigTest;
+    if (builtin.target.os.tag == .macos and builtin.target.cpu.arch == .aarch64) return error.SkipZigTest;
     {
         const v0 = f32x4(1.0, 3.0, 2.0, 7.0);
         const v1 = f32x4(2.0, 1.0, 4.0, math.inf(f32));
@@ -1250,7 +1250,7 @@ pub inline fn clamp(v: anytype, vmin: anytype, vmax: anytype) @TypeOf(v, vmin, v
 }
 test "zmath.clamp" {
     // Calling math.inf causes test to fail!
-    if (builtin.target.os.tag == .macos) return error.SkipZigTest;
+    if (builtin.target.os.tag == .macos and builtin.target.cpu.arch == .aarch64) return error.SkipZigTest;
     {
         const v0 = f32x4(-1.0, 0.2, 1.1, -0.3);
         const v = clamp(v0, splat(F32x4, -0.5), splat(F32x4, 0.5));
@@ -1294,7 +1294,7 @@ pub inline fn saturate(v: anytype) @TypeOf(v) {
 }
 test "zmath.saturate" {
     // Calling math.inf causes test to fail!
-    if (builtin.target.os.tag == .macos) return error.SkipZigTest;
+    if (builtin.target.os.tag == .macos and builtin.target.cpu.arch == .aarch64) return error.SkipZigTest;
     {
         const v0 = f32x4(-1.0, 0.2, 1.1, -0.3);
         const v = saturate(v0);


### PR DESCRIPTION
These tests fail on Apple Silicon but pass on Intel. 