### PR TITLE
ZPM compatibilty 

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -270,7 +270,7 @@ fn testsWindows(
     optimize: std.builtin.OptimizeMode,
     test_step: *std.Build.Step,
 ) void {
-    test_step.dependOn(zd3d12.runTests(b, optimize, target));
+    test_step.dependOn(zd3d12_pkg.tests_step));
     test_step.dependOn(zpix.runTests(b, optimize, target));
     test_step.dependOn(zwin32.runTests(b, optimize, target));
     test_step.dependOn(zxaudio2.runTests(b, optimize, target));

--- a/build.zig
+++ b/build.zig
@@ -242,7 +242,7 @@ fn tests(
     if (target.result.os.tag != .windows) {
         test_step.dependOn(zbullet_pkg.tests_step);
     }
-    test_step.dependOn(zflecs.runTests(b, optimize, target));
+    test_step.dependOn(zflecs_pkg.tests_step);
     test_step.dependOn(zglfw.runTests(b, optimize, target));
     test_step.dependOn(zgpu.runTests(b, optimize, target));
     test_step.dependOn(zgui.runTests(b, optimize, target));
@@ -270,7 +270,7 @@ fn testsWindows(
     optimize: std.builtin.OptimizeMode,
     test_step: *std.Build.Step,
 ) void {
-    test_step.dependOn(zd3d12_pkg.tests_step));
+    test_step.dependOn(zd3d12_pkg.tests_step);
     test_step.dependOn(zpix.runTests(b, optimize, target));
     test_step.dependOn(zwin32.runTests(b, optimize, target));
     test_step.dependOn(zxaudio2.runTests(b, optimize, target));

--- a/build.zig
+++ b/build.zig
@@ -243,7 +243,7 @@ fn tests(
         test_step.dependOn(zbullet_pkg.tests_step);
     }
     test_step.dependOn(zflecs_pkg.tests_step);
-    test_step.dependOn(zglfw.runTests(b, optimize, target));
+    zglfw_pkg.addTests(test_step);
     test_step.dependOn(zgpu.runTests(b, optimize, target));
     test_step.dependOn(zgui.runTests(b, optimize, target));
     test_step.dependOn(zjobs.runTests(b, optimize, target));

--- a/build.zig
+++ b/build.zig
@@ -237,7 +237,7 @@ fn tests(
     optimize: std.builtin.OptimizeMode,
     test_step: *std.Build.Step,
 ) void {
-    test_step.dependOn(zaudio.runTests(b, optimize, target));
+    test_step.dependOn(zaudio_pkg.tests_step);
     // TODO: Get zbullet tests working on Windows again
     if (target.result.os.tag != .windows) {
         test_step.dependOn(zbullet.runTests(b, optimize, target));

--- a/build.zig
+++ b/build.zig
@@ -240,7 +240,7 @@ fn tests(
     test_step.dependOn(zaudio_pkg.tests_step);
     // TODO: Get zbullet tests working on Windows again
     if (target.result.os.tag != .windows) {
-        test_step.dependOn(zbullet.runTests(b, optimize, target));
+        test_step.dependOn(zbullet_pkg.tests_step);
     }
     test_step.dependOn(zflecs.runTests(b, optimize, target));
     test_step.dependOn(zglfw.runTests(b, optimize, target));


### PR DESCRIPTION
Package products (those consumed via a `std.Build.Dependency`) must only be declared once.