### PR TITLE
[zgpu] Remove zglfw dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,31 @@ We build game development ecosystem for [Zig programming language](https://zigla
 * Uses native wgpu implementation ([Dawn](https://github.com/michal-z/dawn-bin)) or OpenGL for cross-platform graphics and DirectX 12 for low-level graphics on Windows
 
 
+## Libraries
+| Library                       | Latest version | Description                                                                                                                |
+|-------------------------------|----------------|----------------------------------------------------------------------------------------------------------------------------|
+| **[zphysics](libs/zphysics)** | 0.0.6          | Zig build sys & bindings ontop of a [C API](https://github.com/zig-gamedev/zig-gamedev/tree/main/libs/zphysics/libs/JoltC) for [Jolt Physics](https://github.com/jrouwe/JoltPhysics)                                                |
+| **[zflecs](libs/zflecs)**     | 0.0.1          | Zig bindings for [flecs](https://github.com/SanderMertens/flecs) ECS                                                       |
+| **[zopengl](libs/zopengl)**   | 0.2.0          | OpenGL loader (supports 4.0 Core Profile and ES 2.0 Profile)                                                               |
+| **[zsdl](libs/zsdl)**         | 0.0.1          | Bindings for SDL2 (wip)                                                                                                    |
+| **[zgpu](libs/zgpu)**         | 0.10.0          | Small helper library built on top of native wgpu implementation ([Dawn](https://github.com/michal-z/dawn-bin))             |
+| **[zgui](libs/zgui)**         | 1.89.6         | Easy to use [dear imgui](https://github.com/ocornut/imgui) bindings (includes [ImPlot](https://github.com/epezent/implot)) |
+| **[zaudio](libs/zaudio)**     | 0.9.3          | Fully-featured audio library built on top of [miniaudio](https://github.com/mackron/miniaudio)                             |
+| **[zmath](libs/zmath)**       | 0.9.6          | SIMD math library for game developers                                                                                      |
+| **[zstbi](libs/zstbi)**       | 0.9.3          | Image reading, writing and resizing with [stb](https://github.com/nothings/stb) libraries                                  |
+| **[zmesh](libs/zmesh)**       | 0.9.0          | Loading, generating, processing and optimizing triangle meshes                                                             |
+| **[ztracy](libs/ztracy)**     | 0.10.0         | Support for CPU profiling with [Tracy](https://github.com/wolfpld/tracy)                                                   |
+| **[zpool](libs/zpool)**       | 0.9.0          | Generic pool & handle implementation                                                                                       |
+| **[zglfw](libs/zglfw)**       | 0.7.0          | Zig build sys & bindings for [GLFW](https://github.com/glfw/glfw)                                  |
+| **[znoise](libs/znoise)**     | 0.1.0          | Zig build sys & bindings for [FastNoiseLite](https://github.com/Auburn/FastNoiseLite)                                                  |
+| **[zjobs](libs/zjobs)**       | 0.1.0          | Generic job queue implementation                                                                                           |
+| **[zbullet](libs/zbullet)**   | 0.2.0          | Zig build sys and bindings and C API for [Bullet physics library](https://github.com/bulletphysics/bullet3)                              |
+| **[zwin32](libs/zwin32)**     | 0.9.0          | Zig bindings for Win32 API (d3d12, d3d11, xaudio2, directml, wasapi and more)                                              |
+| **[zd3d12](libs/zd3d12)**     | 0.9.0          | Helper library for DirectX 12                                                                                              |
+| **[zxaudio2](libs/zxaudio2)** | 0.9.0          | Helper library for XAudio2                                                                                                 |
+| **[zpix](libs/zpix)**         | 0.9.0          | Support for GPU profiling with PIX for Windows                                                                             |
+
+
 ## Getting Started
 
 Download the [latest archive](https://github.com/zig-gamedev/zig-gamedev/archive/refs/heads/main.zip) or clone/submodule with Git.

--- a/build.zig
+++ b/build.zig
@@ -121,7 +121,7 @@ fn packagesCrossPlatform(b: *std.Build, options: Options) void {
     });
     zgpu_pkg = zgpu.package(b, target, optimize, .{
         .options = .{},
-        .deps = .{ .zpool = zpool_pkg, .zglfw = zglfw_pkg },
+        .deps = .{ .zpool = zpool_pkg },
     });
     ztracy_pkg = ztracy.package(b, target, optimize, .{
         .options = .{ .enable_ztracy = true, .enable_fibers = true },

--- a/libs/zgpu/README.md
+++ b/libs/zgpu/README.md
@@ -1,4 +1,4 @@
-# zgpu v0.9.1 - Cross-platform graphics library
+# zgpu v0.10.0 - Cross-platform graphics library
 
 `zgpu` is a small helper library built on top of native wgpu implementation (Dawn).
 
@@ -16,7 +16,7 @@ For more details please see below.
 
 ## Getting started
 
-Copy `zgpu`, `zpool`, `zglfw` and `system-sdk` folders to a `libs` of the root of your project and add the following to your `build.zig.zon` file:
+Copy `zgpu`, `zpool` and `system-sdk` folders to a `libs` of the root of your project and add the following to your `build.zig.zon` file:
 ```zig
 .{
     .name = "your_project_name",
@@ -24,7 +24,6 @@ Copy `zgpu`, `zpool`, `zglfw` and `system-sdk` folders to a `libs` of the root o
     .dependencies = .{
         .zgpu = .{ .path = libs/zgpu" },
         .zpool = .{ .path = libs/zpool" },
-        .zglfw = .{ .path = libs/zglfw" },
         .dawn_x86_64_windows_gnu = .{
             .url = "https://github.com/michal-z/webgpu_dawn-x86_64-windows-gnu/archive/d3a68014e6b6b53fd330a0ccba99e4dcfffddae5.tar.gz",
             .hash = "1220f9448cde02ef3cd51bde2e0850d4489daa0541571d748154e89c6eb46c76a267",
@@ -56,24 +55,20 @@ then in your `build.zig file:
 const std = @import("std");
 const zgpu = @import("zgpu");
 const zpool = @import("zpool");
-const zglfw = @import("zglfw");
 
 pub fn build(b: *std.Build) void {
     ...
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
-    const zglfw_pkg = zglfw.package(b, target, optimize, .{});
     const zpool_pkg = zpool.package(b, target, optimize, .{});
     const zgpu_pkg = zgpu.package(b, target, optimize, .{
         .deps = .{
             .zpool = zpool_pkg,
-            .zglfw = zglfw_pkg,
         },
     });
 
     zgpu_pkg.link(exe);
-    zglfw_pkg.link(exe);
 }
 ```
 
@@ -119,6 +114,27 @@ pub fn build(b: *std.Build) void {
     ...
 }
 ```
+
+### Graphics Context
+Create a `GraphicsContext` using a `WindowProvider`. For example, using [zglfw](https://github.com/zig-gamedev):
+```zig
+const gctx = try zgpu.GraphicsContext.create(
+    alloctor,
+    .{
+        .window = window,
+        .fn_getTime = @ptrCast(&zglfw.getTime),
+        .fn_getFramebufferSize = @ptrCast(&zglfw.Window.getFramebufferSize),
+
+        // optional fields
+        .fn_getWin32Window = @ptrCast(&zglfw.getWin32Window),
+        .fn_getX11Display = @ptrCast(&zglfw.getX11Display),
+        .fn_getX11Window = @ptrCast(&zglfw.getX11Window),
+        .fn_getCocoaWindow = @ptrCast(&zglfw.getCocoaWindow),
+    },
+    .{}, // default context creation options
+);
+```
+
 ### Uniforms
 
 * Implemented as a uniform buffer pool

--- a/libs/zgpu/build.zig
+++ b/libs/zgpu/build.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const log = std.log.scoped(.zgpu);
 
-const zglfw = @import("zglfw");
 const zpool = @import("zpool");
 
 const default_options = struct {
@@ -117,7 +116,6 @@ pub fn package(
     args: struct {
         options: Options = .{},
         deps: struct {
-            zglfw: zglfw.Package,
             zpool: zpool.Package,
         },
     },
@@ -141,7 +139,6 @@ pub fn package(
         .root_source_file = .{ .path = thisDir() ++ "/src/zgpu.zig" },
         .imports = &.{
             .{ .name = "zgpu_options", .module = zgpu_options },
-            .{ .name = "zglfw", .module = args.deps.zglfw.zglfw },
             .{ .name = "zpool", .module = args.deps.zpool.zpool },
         },
     });
@@ -158,7 +155,6 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
-    const zglfw_pkg = zglfw.package(b, target, optimize, .{});
     const zpool_pkg = zpool.package(b, target, optimize, .{});
 
     _ = package(b, target, optimize, .{
@@ -220,7 +216,6 @@ pub fn build(b: *std.Build) void {
             ) orelse default_options.pipeline_layout_pool_size,
         },
         .deps = .{
-            .zglfw = zglfw_pkg,
             .zpool = zpool_pkg,
         },
     });

--- a/libs/zgpu/build.zig.zon
+++ b/libs/zgpu/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "zgpu",
-    .version = "0.9.1",
+    .version = "0.10.0",
     .paths = .{
         "build.zig",
         "build.zig.zon",
@@ -10,7 +10,6 @@
     },
     .dependencies = .{
         .system_sdk = .{ .path = "../system-sdk" },
-        .zglfw = .{ .path = "../zglfw" },
         .zpool = .{ .path = "../zpool" },
         .dawn_x86_64_windows_gnu = .{
             .url = "https://github.com/michal-z/webgpu_dawn-x86_64-windows-gnu/archive/d3a68014e6b6b53fd330a0ccba99e4dcfffddae5.tar.gz",

--- a/samples/bullet_physics_test_wgpu/src/bullet_physics_test_wgpu.zig
+++ b/samples/bullet_physics_test_wgpu/src/bullet_physics_test_wgpu.zig
@@ -75,6 +75,7 @@ const ccd_swept_sphere_radius: f32 = 0.5;
 const default_gravity: f32 = 10.0;
 
 const DemoState = struct {
+    window: *zglfw.Window,
     gctx: *zgpu.GraphicsContext,
 
     mesh_pipe: zgpu.RenderPipelineHandle = .{},
@@ -117,7 +118,19 @@ const DemoState = struct {
 };
 
 fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
-    const gctx = try zgpu.GraphicsContext.create(allocator, window, .{});
+    const gctx = try zgpu.GraphicsContext.create(
+        allocator,
+        .{
+            .window = window,
+            .fn_getTime = @ptrCast(&zglfw.getTime),
+            .fn_getFramebufferSize = @ptrCast(&zglfw.Window.getFramebufferSize),
+            .fn_getWin32Window = @ptrCast(&zglfw.getWin32Window),
+            .fn_getX11Display = @ptrCast(&zglfw.getX11Display),
+            .fn_getX11Window = @ptrCast(&zglfw.getX11Window),
+            .fn_getCocoaWindow = @ptrCast(&zglfw.getCocoaWindow),
+        },
+        .{},
+    );
     errdefer gctx.destroy(allocator);
 
     var arena_state = std.heap.ArenaAllocator.init(allocator);
@@ -208,6 +221,7 @@ fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
 
     const demo = try allocator.create(DemoState);
     demo.* = .{
+        .window = window,
         .gctx = gctx,
         .vertex_buf = vertex_buf,
         .index_buf = index_buf,
@@ -380,7 +394,7 @@ fn update(demo: *DemoState) void {
     }
     zgui.end();
 
-    const window = demo.gctx.window;
+    const window = demo.window;
 
     // Handle camera rotation with mouse.
     {
@@ -1195,7 +1209,7 @@ fn initMeshes(
 }
 
 fn objectPicking(demo: *DemoState, want_capture_mouse: bool) void {
-    const window = demo.gctx.window;
+    const window = demo.window;
 
     const mouse_button_is_down = window.getMouseButton(.left) == .press and !want_capture_mouse;
 

--- a/samples/frame_pacing_wgpu/src/frame_pacing_wgpu.zig
+++ b/samples/frame_pacing_wgpu/src/frame_pacing_wgpu.zig
@@ -38,9 +38,21 @@ const Surface = struct {
         zglfw.windowHintTyped(.client_api, .no_api);
         const window = try zglfw.Window.create(width, height, window_title, monitor);
 
-        const gctx = try zgpu.GraphicsContext.create(allocator, window, .{
-            .present_mode = present_mode,
-        });
+        const gctx = try zgpu.GraphicsContext.create(
+            allocator,
+            .{
+                .window = window,
+                .fn_getTime = @ptrCast(&zglfw.getTime),
+                .fn_getFramebufferSize = @ptrCast(&zglfw.Window.getFramebufferSize),
+                .fn_getWin32Window = @ptrCast(&zglfw.getWin32Window),
+                .fn_getX11Display = @ptrCast(&zglfw.getX11Display),
+                .fn_getX11Window = @ptrCast(&zglfw.getX11Window),
+                .fn_getCocoaWindow = @ptrCast(&zglfw.getCocoaWindow),
+            },
+            .{
+                .present_mode = present_mode,
+            },
+        );
 
         zgui.init(allocator);
         zgui.plot.init();

--- a/samples/gamepad_wgpu/src/gamepad_wgpu.zig
+++ b/samples/gamepad_wgpu/src/gamepad_wgpu.zig
@@ -14,7 +14,19 @@ const DemoState = struct {
 };
 
 fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
-    const gctx = try zgpu.GraphicsContext.create(allocator, window, .{});
+    const gctx = try zgpu.GraphicsContext.create(
+        allocator,
+        .{
+            .window = window,
+            .fn_getTime = @ptrCast(&zglfw.getTime),
+            .fn_getFramebufferSize = @ptrCast(&zglfw.Window.getFramebufferSize),
+            .fn_getWin32Window = @ptrCast(&zglfw.getWin32Window),
+            .fn_getX11Display = @ptrCast(&zglfw.getX11Display),
+            .fn_getX11Window = @ptrCast(&zglfw.getX11Window),
+            .fn_getCocoaWindow = @ptrCast(&zglfw.getCocoaWindow),
+        },
+        .{},
+    );
     errdefer gctx.destroy(allocator);
 
     const success = zglfw.Gamepad.updateMappings(@embedFile("gamecontrollerdb.txt"));

--- a/samples/gui_test_wgpu/src/gui_test_wgpu.zig
+++ b/samples/gui_test_wgpu/src/gui_test_wgpu.zig
@@ -21,7 +21,19 @@ const DemoState = struct {
 };
 
 fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
-    const gctx = try zgpu.GraphicsContext.create(allocator, window, .{});
+    const gctx = try zgpu.GraphicsContext.create(
+        allocator,
+        .{
+            .window = window,
+            .fn_getTime = @ptrCast(&zglfw.getTime),
+            .fn_getFramebufferSize = @ptrCast(&zglfw.Window.getFramebufferSize),
+            .fn_getWin32Window = @ptrCast(&zglfw.getWin32Window),
+            .fn_getX11Display = @ptrCast(&zglfw.getX11Display),
+            .fn_getX11Window = @ptrCast(&zglfw.getX11Window),
+            .fn_getCocoaWindow = @ptrCast(&zglfw.getCocoaWindow),
+        },
+        .{},
+    );
     errdefer gctx.destroy(allocator);
 
     var arena_state = std.heap.ArenaAllocator.init(allocator);

--- a/samples/layers_wgpu/src/graphics.zig
+++ b/samples/layers_wgpu/src/graphics.zig
@@ -48,7 +48,19 @@ pub const State = struct {
     depth_texture_view: zgpu.TextureViewHandle,
 
     pub fn init(allocator: std.mem.Allocator, window: *zglfw.Window) !State {
-        const gctx = try zgpu.GraphicsContext.create(allocator, window, .{});
+        const gctx = try zgpu.GraphicsContext.create(
+            allocator,
+            .{
+                .window = window,
+                .fn_getTime = @ptrCast(&zglfw.getTime),
+                .fn_getFramebufferSize = @ptrCast(&zglfw.Window.getFramebufferSize),
+                .fn_getWin32Window = @ptrCast(&zglfw.getWin32Window),
+                .fn_getX11Display = @ptrCast(&zglfw.getX11Display),
+                .fn_getX11Window = @ptrCast(&zglfw.getX11Window),
+                .fn_getCocoaWindow = @ptrCast(&zglfw.getCocoaWindow),
+            },
+            .{},
+        );
         errdefer gctx.destroy(allocator);
 
         zgui.init(allocator);

--- a/samples/minimal_glfw_d3d12/src/minimal_glfw_d3d12.zig
+++ b/samples/minimal_glfw_d3d12/src/minimal_glfw_d3d12.zig
@@ -24,7 +24,7 @@ pub fn main() !void {
     const glfw_window = try glfw.Window.create(1600, 1200, window_name, null);
     defer glfw_window.destroy();
 
-    const window = try glfw.native.getWin32Window(glfw_window);
+    const window = glfw.getWin32Window(glfw_window) orelse return error.FailedToGetWin32Window;
     var gctx = zd3d12.GraphicsContext.init(allocator, window);
     defer gctx.deinit(allocator);
 

--- a/samples/minimal_zgpu_zgui/src/minimal_zgpu_zgui.zig
+++ b/samples/minimal_zgpu_zgui/src/minimal_zgpu_zgui.zig
@@ -29,7 +29,19 @@ pub fn main() !void {
     defer _ = gpa_state.deinit();
     const gpa = gpa_state.allocator();
 
-    const gctx = try zgpu.GraphicsContext.create(gpa, window, .{});
+    const gctx = try zgpu.GraphicsContext.create(
+        gpa,
+        .{
+            .window = window,
+            .fn_getTime = @ptrCast(&zglfw.getTime),
+            .fn_getFramebufferSize = @ptrCast(&zglfw.Window.getFramebufferSize),
+            .fn_getWin32Window = @ptrCast(&zglfw.getWin32Window),
+            .fn_getX11Display = @ptrCast(&zglfw.getX11Display),
+            .fn_getX11Window = @ptrCast(&zglfw.getX11Window),
+            .fn_getCocoaWindow = @ptrCast(&zglfw.getCocoaWindow),
+        },
+        .{},
+    );
     defer gctx.destroy(gpa);
 
     const scale_factor = scale_factor: {

--- a/samples/monolith/src/monolith.zig
+++ b/samples/monolith/src/monolith.zig
@@ -527,6 +527,7 @@ const DebugRenderer = struct {
 };
 
 const DemoState = struct {
+    window: *zglfw.Window,
     gctx: *zgpu.GraphicsContext,
 
     mesh_render_pipe: zgpu.RenderPipelineHandle = .{},
@@ -654,7 +655,19 @@ fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
     //
     // Graphics
     //
-    const gctx = try zgpu.GraphicsContext.create(allocator, window, .{});
+    const gctx = try zgpu.GraphicsContext.create(
+        allocator,
+        .{
+            .window = window,
+            .fn_getTime = @ptrCast(&zglfw.getTime),
+            .fn_getFramebufferSize = @ptrCast(&zglfw.Window.getFramebufferSize),
+            .fn_getWin32Window = @ptrCast(&zglfw.getWin32Window),
+            .fn_getX11Display = @ptrCast(&zglfw.getX11Display),
+            .fn_getX11Window = @ptrCast(&zglfw.getX11Window),
+            .fn_getCocoaWindow = @ptrCast(&zglfw.getCocoaWindow),
+        },
+        .{},
+    );
     errdefer gctx.destroy(allocator);
 
     // Uniform buffer and layout
@@ -735,6 +748,7 @@ fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
     //
     const demo = try allocator.create(DemoState);
     demo.* = .{
+        .window = window,
         .gctx = gctx,
         .uniform_bg = uniform_bg,
         .vertex_buf = vertex_buf,
@@ -959,7 +973,7 @@ fn destroy(allocator: std.mem.Allocator, demo: *DemoState) void {
 }
 
 fn update(demo: *DemoState) void {
-    const window = demo.gctx.window;
+    const window = demo.window;
 
     { // Handle camera rotation with mouse.
         const cursor_pos = window.getCursorPos();

--- a/samples/physics_test_wgpu/src/physics_test_wgpu.zig
+++ b/samples/physics_test_wgpu/src/physics_test_wgpu.zig
@@ -140,6 +140,7 @@ const ContactListener = extern struct {
 };
 
 const DemoState = struct {
+    window: *zglfw.Window,
     gctx: *zgpu.GraphicsContext,
 
     render_pipe: zgpu.RenderPipelineHandle = .{},
@@ -257,7 +258,19 @@ fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
     //
     // Graphics
     //
-    const gctx = try zgpu.GraphicsContext.create(allocator, window, .{});
+    const gctx = try zgpu.GraphicsContext.create(
+        allocator,
+        .{
+            .window = window,
+            .fn_getTime = @ptrCast(&zglfw.getTime),
+            .fn_getFramebufferSize = @ptrCast(&zglfw.Window.getFramebufferSize),
+            .fn_getWin32Window = @ptrCast(&zglfw.getWin32Window),
+            .fn_getX11Display = @ptrCast(&zglfw.getX11Display),
+            .fn_getX11Window = @ptrCast(&zglfw.getX11Window),
+            .fn_getCocoaWindow = @ptrCast(&zglfw.getCocoaWindow),
+        },
+        .{},
+    );
     errdefer gctx.destroy(allocator);
 
     // Uniform buffer and layout
@@ -376,6 +389,7 @@ fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
     //
     const demo = try allocator.create(DemoState);
     demo.* = .{
+        .window = window,
         .gctx = gctx,
         .uniform_bg = uniform_bg,
         .vertex_buf = vertex_buf,
@@ -433,7 +447,7 @@ fn update(demo: *DemoState) void {
     zgui.backend.newFrame(demo.gctx.swapchain_descriptor.width, demo.gctx.swapchain_descriptor.height);
     demo.physics_system.update(1.0 / 60.0, .{}) catch unreachable;
 
-    const window = demo.gctx.window;
+    const window = demo.window;
 
     // Handle camera rotation with mouse.
     {

--- a/samples/procedural_mesh_wgpu/src/procedural_mesh_wgpu.zig
+++ b/samples/procedural_mesh_wgpu/src/procedural_mesh_wgpu.zig
@@ -44,6 +44,7 @@ const Drawable = struct {
 };
 
 const DemoState = struct {
+    window: *zglfw.Window,
     gctx: *zgpu.GraphicsContext,
 
     pipeline: zgpu.RenderPipelineHandle,
@@ -303,7 +304,19 @@ fn initScene(
 }
 
 fn init(allocator: std.mem.Allocator, window: *zglfw.Window) !DemoState {
-    const gctx = try zgpu.GraphicsContext.create(allocator, window, .{});
+    const gctx = try zgpu.GraphicsContext.create(
+        allocator,
+        .{
+            .window = window,
+            .fn_getTime = @ptrCast(&zglfw.getTime),
+            .fn_getFramebufferSize = @ptrCast(&zglfw.Window.getFramebufferSize),
+            .fn_getWin32Window = @ptrCast(&zglfw.getWin32Window),
+            .fn_getX11Display = @ptrCast(&zglfw.getX11Display),
+            .fn_getX11Window = @ptrCast(&zglfw.getX11Window),
+            .fn_getCocoaWindow = @ptrCast(&zglfw.getCocoaWindow),
+        },
+        .{},
+    );
     errdefer gctx.destroy(allocator);
 
     var arena_state = std.heap.ArenaAllocator.init(allocator);
@@ -415,6 +428,7 @@ fn init(allocator: std.mem.Allocator, window: *zglfw.Window) !DemoState {
     const depth = createDepthTexture(gctx);
 
     return DemoState{
+        .window = window,
         .gctx = gctx,
         .pipeline = pipeline,
         .bind_group = bind_group,
@@ -453,7 +467,7 @@ fn update(demo: *DemoState) void {
     }
     zgui.end();
 
-    const window = demo.gctx.window;
+    const window = demo.window;
 
     // Handle camera rotation with mouse.
     {

--- a/samples/textured_quad_wgpu/src/textured_quad_wgpu.zig
+++ b/samples/textured_quad_wgpu/src/textured_quad_wgpu.zig
@@ -72,7 +72,19 @@ const DemoState = struct {
 };
 
 fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
-    const gctx = try zgpu.GraphicsContext.create(allocator, window, .{});
+    const gctx = try zgpu.GraphicsContext.create(
+        allocator,
+        .{
+            .window = window,
+            .fn_getTime = @ptrCast(&zglfw.getTime),
+            .fn_getFramebufferSize = @ptrCast(&zglfw.Window.getFramebufferSize),
+            .fn_getWin32Window = @ptrCast(&zglfw.getWin32Window),
+            .fn_getX11Display = @ptrCast(&zglfw.getX11Display),
+            .fn_getX11Window = @ptrCast(&zglfw.getX11Window),
+            .fn_getCocoaWindow = @ptrCast(&zglfw.getCocoaWindow),
+        },
+        .{},
+    );
     errdefer gctx.destroy(allocator);
 
     var arena_state = std.heap.ArenaAllocator.init(allocator);

--- a/samples/triangle_wgpu/src/triangle_wgpu.zig
+++ b/samples/triangle_wgpu/src/triangle_wgpu.zig
@@ -54,7 +54,19 @@ const DemoState = struct {
 };
 
 fn init(allocator: std.mem.Allocator, window: *zglfw.Window) !DemoState {
-    const gctx = try zgpu.GraphicsContext.create(allocator, window, .{});
+    const gctx = try zgpu.GraphicsContext.create(
+        allocator,
+        .{
+            .window = window,
+            .fn_getTime = @ptrCast(&zglfw.getTime),
+            .fn_getFramebufferSize = @ptrCast(&zglfw.Window.getFramebufferSize),
+            .fn_getWin32Window = @ptrCast(&zglfw.getWin32Window),
+            .fn_getX11Display = @ptrCast(&zglfw.getX11Display),
+            .fn_getX11Window = @ptrCast(&zglfw.getX11Window),
+            .fn_getCocoaWindow = @ptrCast(&zglfw.getCocoaWindow),
+        },
+        .{},
+    );
     errdefer gctx.destroy(allocator);
 
     // Create a bind group layout needed for our render pipeline.


### PR DESCRIPTION
Removes zglfw dependency from zgpu. Introduces `WindowProvider` struct which the user fills out when creating a `GraphicsContext`

For example, to setup a `GraphicsContext` using zglfw:
 ```zig
 const gctx = try zgpu.GraphicsContext.create(
     alloctor,
     .{
         .window = window,
         .fn_getTime = @ptrCast(&zglfw.getTime),
         .fn_getFramebufferSize = @ptrCast(&zglfw.Window.getFramebufferSize),
         .fn_getWin32Window = @ptrCast(&zglfw.getWin32Window),
         .fn_getX11Display = @ptrCast(&zglfw.getX11Display),
         .fn_getX11Window = @ptrCast(&zglfw.getX11Window),
         .fn_getCocoaWindow = @ptrCast(&zglfw.getCocoaWindow),
     },
     .{}, // default context creation options
 );
 ```

Platform specific fn pointers default to `undefined`