### PR TITLE
zopengl: fixed the order of the fields in the wrapper clear Bitfield

### DIFF
--- a/libs/zopengl/src/wrapper.zig
+++ b/libs/zopengl/src/wrapper.zig
@@ -1520,11 +1520,11 @@ pub fn Wrap(comptime bindings: anytype) type {
         // pub var clear: *const fn (mask: Bitfield) callconv(.C) void = undefined;
         pub fn clear(mask: packed struct(Bitfield) {
             __unused1: u8 = 0,
-            color: bool = false,
-            __unused2: u1 = 0,
             depth: bool = false,
-            __unused3: u3 = 0,
+            __unused2: u1 = 0,
             stencil: bool = false,
+            __unused3: u3 = 0,
+            color: bool = false,
             __unused4: u17 = 0,
         }) void {
             bindings.clear(@bitCast(mask));


### PR DESCRIPTION
It appears to me that the fields in the clear function Bitfield are slightly out of order so this PR attempts to fix that.
If I have missed something, or more is needed for this PR, please let know as I will be happy to correct anything.

As reference:
pub const DEPTH_BUFFER_BIT = 0x00000100;
pub const STENCIL_BUFFER_BIT = 0x00000400;
pub const COLOR_BUFFER_BIT = 0x00004000;

Thanks!