### PR TITLE
zstbi tests

### DIFF
--- a/libs/zstbi/src/zstbi.zig
+++ b/libs/zstbi/src/zstbi.zig
@@ -585,13 +585,30 @@ test "zstbi resize" {
     try testing.expect(im2.num_components == 3);
 }
 
-test "zstbi write" {
+test "zstbi write and load file" {
     init(testing.allocator);
     defer deinit();
 
-    var im1 = try Image.createEmpty(8, 6, 4, .{});
-    defer im1.deinit();
+    var img = try Image.createEmpty(8, 6, 4, .{});
+    defer img.deinit();
 
-    try im1.writeToFile("test_img.png", ImageWriteFormat.png);
-    // try im1.writeToFile("test_img.jpg", .{ .jpg = .{ .quality = 80 } });
+    try img.writeToFile("test_img.png", ImageWriteFormat.png);
+    try img.writeToFile("test_img.jpg", .{ .jpg = .{ .quality = 80 } });
+
+    var img_png = try Image.loadFromFile("test_img.png", 0);
+    defer img_png.deinit();
+
+    try testing.expect(img_png.width == img.width);
+    try testing.expect(img_png.height == img.height);
+    try testing.expect(img_png.num_components == img.num_components);
+
+    var img_jpg = try Image.loadFromFile("test_img.jpg", 0);
+    defer img_jpg.deinit();
+
+    try testing.expect(img_jpg.width == img.width);
+    try testing.expect(img_jpg.height == img.height);
+    try testing.expect(img_jpg.num_components == 3); // RGB JPEG
+
+    try std.fs.cwd().deleteFile("test_img.png");
+    try std.fs.cwd().deleteFile("test_img.jpg");
 }

--- a/libs/zstbi/src/zstbi.zig
+++ b/libs/zstbi/src/zstbi.zig
@@ -529,6 +529,7 @@ extern fn stbi_write_jpg(
     data: [*]const u8,
     quality: c_int,
 ) c_int;
+
 extern fn stbi_write_png(
     filename: [*:0]const u8,
     w: c_int,
@@ -577,12 +578,12 @@ test "zstbi resize" {
     var im1 = try Image.createEmpty(32, 32, 4, .{});
     defer im1.deinit();
 
-    var im2 = try Image.createEmpty(8, 6, 3, .{});
+    var im2 = im1.resize(8, 6);
     defer im2.deinit();
 
     try testing.expect(im2.width == 8);
     try testing.expect(im2.height == 6);
-    try testing.expect(im2.num_components == 3);
+    try testing.expect(im2.num_components == 4);
 }
 
 test "zstbi write and load file" {

--- a/libs/zstbi/src/zstbi.zig
+++ b/libs/zstbi/src/zstbi.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const testing = std.testing;
 const assert = std.debug.assert;
 
 pub fn init(allocator: std.mem.Allocator) void {
@@ -557,10 +558,40 @@ extern fn stbi_write_jpg_to_func(
     quality: c_int,
 ) c_int;
 
-test "zstbi.basic" {
-    init(std.testing.allocator);
+test "zstbi basic" {
+    init(testing.allocator);
     defer deinit();
 
-    var image = try Image.createEmpty(64, 64, 4, .{});
-    defer image.deinit();
+    var im1 = try Image.createEmpty(8, 6, 4, .{});
+    defer im1.deinit();
+
+    try testing.expect(im1.width == 8);
+    try testing.expect(im1.height == 6);
+    try testing.expect(im1.num_components == 4);
+}
+
+test "zstbi resize" {
+    init(testing.allocator);
+    defer deinit();
+
+    var im1 = try Image.createEmpty(32, 32, 4, .{});
+    defer im1.deinit();
+
+    var im2 = try Image.createEmpty(8, 6, 3, .{});
+    defer im2.deinit();
+
+    try testing.expect(im2.width == 8);
+    try testing.expect(im2.height == 6);
+    try testing.expect(im2.num_components == 3);
+}
+
+test "zstbi write" {
+    init(testing.allocator);
+    defer deinit();
+
+    var im1 = try Image.createEmpty(8, 6, 4, .{});
+    defer im1.deinit();
+
+    try im1.writeToFile("test_img.png", ImageWriteFormat.png);
+    // try im1.writeToFile("test_img.jpg", .{ .jpg = .{ .quality = 80 } });
 }

--- a/libs/zstbi/src/zstbi.zig
+++ b/libs/zstbi/src/zstbi.zig
@@ -590,6 +590,10 @@ test "zstbi write and load file" {
     init(testing.allocator);
     defer deinit();
 
+    const pth = try std.fs.selfExeDirPathAlloc(testing.allocator);
+    defer testing.allocator.free(pth);
+    try std.os.chdir(pth);
+
     var img = try Image.createEmpty(8, 6, 4, .{});
     defer img.deinit();
 


### PR DESCRIPTION
Hi folks!
I am working on integrating stb_image into Zig for a small project and I found this repo to be an awesome source of inspiration! Great job!

This small PR adds some tests to stb_image libraries.
The last test, where I'm trying to save a JPEG image, is failing with this long error:

```
zig version
0.12.0-dev.2631+3069669bc


zig test src/zstbi.zig -cflags -std=c99 -- /root/PWD/libs/stbi/stb_image.c -lc --cache-dir /root/PWD/zig-cache --global-cache-dir /root/.cache/zig -I /root/PWD/vendor

Test [3/3] test.zstbi write... Illegal instruction at address 0x10c306c
libs/stbi/stb_image_write.h:1263:14: 0x10c306c in stbiw__jpg_writeBits (/root/PWD/libs/stbi/stb_image.c)
      bitBuf <<= 8;
             ^
libs/stbi/stb_image_write.h:1363:7: 0x10c2717 in stbiw__jpg_processDU (/root/PWD/libs/stbi/stb_image.c)
      stbiw__jpg_writeBits(s, bitBuf, bitCnt, bits);
      ^
libs/stbi/stb_image_write.h:1550:22: 0x104297a in stbi_write_jpg_core (/root/PWD/libs/stbi/stb_image.c)
               DCY = stbiw__jpg_processDU(s, &bitBuf, &bitCnt, Y+0,   16, fdtbl_Y, DCY, YDC_HT, YAC_HT);
                     ^
libs/stbi/stb_image_write.h:1620:15: 0x1044088 in stbi_write_jpg (/root/PWD/libs/stbi/stb_image.c)
      int r = stbi_write_jpg_core(&s, x, y, comp, data, quality);
              ^
/root/PWD/src/zstbi.zig:298:46: 0x10c68d6 in writeToFile (test)
            .jpg => |settings| stbi_write_jpg(
                                             ^
/root/PWD/src/zstbi.zig:596:24: 0x10c66ba in test.zstbi write (test)
    try im1.writeToFile("test_img.jpg", .{ .jpg = .{ .quality = 80 } });
                       ^
/root/.asdf/installs/zig/master/lib/test_runner.zig:181:28: 0x10d1d72 in mainTerminal (test)
        } else test_fn.func();
                           ^
/root/.asdf/installs/zig/master/lib/test_runner.zig:36:28: 0x10c717b in main (test)
        return mainTerminal();
                           ^
/root/.asdf/installs/zig/master/lib/std/start.zig:575:22: 0x10c6c74 in main (test)
            root.main();
                     ^
???:?:?: 0x7f5f6e029d8f in ??? (libc.so.6)
Unwind information for `libc.so.6:0x7f5f6e029d8f` was not available, trace may be incomplete

error: the following test command crashed:
/root/PWD/zig-cache/o/5a59c14ba41ac5d6cbed86bfcdd11a5a/test
```

I suppose nobody is using this feature or writing JPEG images? Or am I doing something wrong? This is more like an issue + PR in one, I hope that's OK.
Any feedback is appreciated :) Cheers!
