### PR TITLE
zgui: Add Drag And Drop API

### DIFF
--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -3399,7 +3399,7 @@ const Payload = extern struct {
     source_id: c_uint = 0,
     source_parent_id: c_uint = 0,
     data_frame_count: c_int = -1,
-    data_type: [32 + 1]c_char,
+    data_type: [32:0]c_char,
     preview: bool = false,
     delivery: bool = false,
 
@@ -3430,7 +3430,7 @@ pub fn beginDragDropSource(flags: DragDropFlags) bool {
     return zguiBeginDragDropSource(flags);
 }
 pub fn setDragDropPayload(payload_type: [*:0]const u8, data: []const u8, cond: Condition) bool {
-    return zguiSetDragDropPayload(payload_type, data.ptr, data.len, cond);
+    return zguiSetDragDropPayload(payload_type, @alignCast(@ptrCast(data.ptr)), data.len, cond);
 }
 pub fn endDragDropSource() void {
     zguiEndDragDropSource();
@@ -3448,7 +3448,7 @@ pub fn getDragDropPayload() ?*Payload {
     return zguiGetDragDropPayload();
 }
 extern fn zguiBeginDragDropSource(flags: DragDropFlags) bool;
-extern fn zguiSetDragDropPayload(type: [*:0]const u8, data: *anyopaque, sz: usize, cond: Condition) bool;
+extern fn zguiSetDragDropPayload(type: [*:0]const u8, data: *const anyopaque, sz: usize, cond: Condition) bool;
 extern fn zguiEndDragDropSource() void;
 extern fn zguiBeginDragDropTarget() bool;
 extern fn zguiAcceptDragDropPayload(type: [*:0]const u8, flags: DragDropFlags) [*c]Payload;

--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -3441,7 +3441,7 @@ pub fn acceptDragDropPayload(payload_type: [*:0]const u8, flags: DragDropFlags) 
 pub fn endDragDropTarget() void {
     zguiEndDragDropTarget();
 }
-pub fn getDragDropPayload() *Payload {
+pub fn getDragDropPayload() ?*Payload {
     return zguiGetDragDropPayload();
 }
 extern fn zguiBeginDragDropSource(flags: DragDropFlags) bool;

--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -3371,6 +3371,88 @@ extern fn zguiGetMouseDragDelta(button: MouseButton, lock_threshold: f32, delta:
 extern fn zguiResetMouseDragDelta(button: MouseButton) void;
 //--------------------------------------------------------------------------------------------------
 //
+// Drag and Drop
+//
+//--------------------------------------------------------------------------------------------------
+pub const DragDropFlags = packed struct(u32) {
+    source_no_preview_tooltip: bool = false,
+    source_no_disable_hover: bool = false,
+    source_no_hold_open_to_others: bool = false,
+    source_allow_null_id: bool = false,
+    source_extern: bool = false,
+    source_auto_expire_payload: bool = false,
+
+    _padding0: u4 = 0,
+
+    accept_before_delivery: bool = false,
+    accept_no_draw_default_rect: bool = false,
+    accept_no_preview_tooltip: bool = false,
+    accept_peek_only: bool = false,
+
+    _padding1: u18 = 0,
+};
+
+const Payload = extern struct {
+    data: *anyopaque = null,
+    data_size: i32 = 0,
+    source_id: u32 = 0,
+    source_parent_id: u32 = 0,
+    data_frame_count: i32 = -1,
+    data_type: [32 + 1]u8,
+    preview: bool = false,
+    delivery: bool = false,
+
+    /// `pub fn init() Payload`
+    pub const init = zguiImGuiPayload_Init;
+    extern fn zguiImGuiPayload_Init() Payload;
+
+    /// `pub fn clear(payload: *Payload) void`
+    pub const clear = zguiImGuiPayload_Clear;
+    extern fn zguiImGuiPayload_Clear(payload: *Payload) void;
+
+    /// `pub fn isDataType(payload: *const Payload, type: [*:0]const u8) bool`
+    pub const isDataType = zguiImGuiPayload_IsDataType;
+    extern fn zguiImGuiPayload_IsDataType(payload: *const Payload, type: [*:0]const u8) bool;
+
+    /// `pub fn isPreview(payload: *const Payload) bool`
+    pub const isPreview = zguiImGuiPayload_IsPreview;
+    extern fn zguiImGuiPayload_IsPreview(payload: *const Payload) bool;
+
+    /// `pub fn isDelivery(payload: *const Payload) bool;
+    pub const isDelivery = zguiImGuiPayload_IsDelivery;
+    extern fn zguiImGuiPayload_IsDelivery(payload: *const Payload) bool;
+};
+
+pub fn beginDragDropSource(flags: DragDropFlags) bool {
+    return zguiBeginDragDropSource(flags);
+}
+pub fn setDragDropPayload(payload_type: [*:0]const u8, data: *anyopaque, sz: usize, cond: Condition) bool {
+    return zguiSetDragDropPayload(payload_type, data, sz, cond);
+}
+pub fn endDragDropSource() void {
+    zguiEndDragDropSource();
+}
+pub fn beginDragDropTarget() bool {
+    return zguiBeginDragDropTarget();
+}
+pub fn acceptDragDropPayload(payload_type: [*:0]const u8, flags: DragDropFlags) ?*Payload {
+    return zguiAcceptDragDropPayload(payload_type, flags);
+}
+pub fn endDragDropTarget() void {
+    zguiEndDragDropTarget();
+}
+pub fn getDragDropPayload() *Payload {
+    return zguiGetDragDropPayload();
+}
+extern fn zguiBeginDragDropSource(flags: DragDropFlags) bool;
+extern fn zguiSetDragDropPayload(type: [*:0]const u8, data: *anyopaque, sz: usize, cond: Condition) bool;
+extern fn zguiEndDragDropSource() void;
+extern fn zguiBeginDragDropTarget() bool;
+extern fn zguiAcceptDragDropPayload(type: [*:0]const u8, flags: DragDropFlags) [*c]Payload;
+extern fn zguiEndDragDropTarget() void;
+extern fn zguiGetDragDropPayload() [*c]Payload;
+//--------------------------------------------------------------------------------------------------
+//
 // DrawFlags
 //
 //--------------------------------------------------------------------------------------------------

--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -3429,6 +3429,8 @@ const Payload = extern struct {
 pub fn beginDragDropSource(flags: DragDropFlags) bool {
     return zguiBeginDragDropSource(flags);
 }
+
+/// Note: `payload_type` can be at most 32 characters long
 pub fn setDragDropPayload(payload_type: [*:0]const u8, data: []const u8, cond: Condition) bool {
     return zguiSetDragDropPayload(payload_type, @alignCast(@ptrCast(data.ptr)), data.len, cond);
 }
@@ -3438,6 +3440,8 @@ pub fn endDragDropSource() void {
 pub fn beginDragDropTarget() bool {
     return zguiBeginDragDropTarget();
 }
+
+/// Note: `payload_type` can be at most 32 characters long
 pub fn acceptDragDropPayload(payload_type: [*:0]const u8, flags: DragDropFlags) ?*Payload {
     return zguiAcceptDragDropPayload(payload_type, flags);
 }

--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -3374,7 +3374,7 @@ extern fn zguiResetMouseDragDelta(button: MouseButton) void;
 // Drag and Drop
 //
 //--------------------------------------------------------------------------------------------------
-pub const DragDropFlags = packed struct(u32) {
+pub const DragDropFlags = packed struct(c_int) {
     source_no_preview_tooltip: bool = false,
     source_no_disable_hover: bool = false,
     source_no_hold_open_to_others: bool = false,
@@ -3387,24 +3387,27 @@ pub const DragDropFlags = packed struct(u32) {
     accept_before_delivery: bool = false,
     accept_no_draw_default_rect: bool = false,
     accept_no_preview_tooltip: bool = false,
-    accept_peek_only: bool = false,
 
-    _padding1: u18 = 0,
+    _padding1: u19 = 0,
+
+    pub const accept_peek_only = @This(){ .accept_before_delivery = true, .accept_no_draw_default_rect = true };
 };
 
 const Payload = extern struct {
     data: *anyopaque = null,
-    data_size: i32 = 0,
-    source_id: u32 = 0,
-    source_parent_id: u32 = 0,
-    data_frame_count: i32 = -1,
-    data_type: [32 + 1]u8,
+    data_size: c_int = 0,
+    source_id: c_uint = 0,
+    source_parent_id: c_uint = 0,
+    data_frame_count: c_int = -1,
+    data_type: [32 + 1]c_char,
     preview: bool = false,
     delivery: bool = false,
 
-    /// `pub fn init() Payload`
-    pub const init = zguiImGuiPayload_Init;
-    extern fn zguiImGuiPayload_Init() Payload;
+    pub fn init() Payload {
+        var payload = Payload{};
+        payload.clear();
+        return payload;
+    }
 
     /// `pub fn clear(payload: *Payload) void`
     pub const clear = zguiImGuiPayload_Clear;
@@ -3426,8 +3429,8 @@ const Payload = extern struct {
 pub fn beginDragDropSource(flags: DragDropFlags) bool {
     return zguiBeginDragDropSource(flags);
 }
-pub fn setDragDropPayload(payload_type: [*:0]const u8, data: *anyopaque, sz: usize, cond: Condition) bool {
-    return zguiSetDragDropPayload(payload_type, data, sz, cond);
+pub fn setDragDropPayload(payload_type: [*:0]const u8, data: []const u8, cond: Condition) bool {
+    return zguiSetDragDropPayload(payload_type, data.ptr, data.len, cond);
 }
 pub fn endDragDropSource() void {
     zguiEndDragDropSource();

--- a/libs/zgui/src/zgui.cpp
+++ b/libs/zgui/src/zgui.cpp
@@ -460,6 +460,54 @@ ZGUI_API bool zguiDragScalarN(
     return ImGui::DragScalarN(label, data_type, p_data, components, v_speed, p_min, p_max, format, flags);
 }
 
+ZGUI_API bool zguiBeginDragDropSource(ImGuiDragDropFlags flags = 0) {
+  return ImGui::BeginDragDropSource(flags);
+}
+ZGUI_API bool zguiSetDragDropPayload(
+    const char* type,
+    const void* data,
+    size_t sz,
+    ImGuiCond cond = 0
+) {
+  return ImGui::SetDragDropPayload(type, data, sz, cond);
+}
+ZGUI_API void zguiEndDragDropSource() {
+  return ImGui::EndDragDropSource();
+}
+ZGUI_API bool zguiBeginDragDropTarget() {
+  return ImGui::BeginDragDropTarget();
+}
+ZGUI_API const ImGuiPayload* zguiAcceptDragDropPayload(
+    const char* type,
+    ImGuiDragDropFlags flags = 0
+) {
+  return ImGui::AcceptDragDropPayload(type);
+}
+ZGUI_API void zguiEndDragDropTarget() {
+  return ImGui::EndDragDropTarget();
+}
+ZGUI_API const ImGuiPayload* zguiGetDragDropPayload() {
+  return ImGui::GetDragDropPayload();
+}
+
+
+ZGUI_API ImGuiPayload zguiImGuiPayload_Init() { return ImGuiPayload(); }
+
+ZGUI_API void zguiImGuiPayload_Clear(ImGuiPayload* payload) { payload->Clear(); }
+
+ZGUI_API bool zguiImGuiPayload_IsDataType(const ImGuiPayload* payload, const char* type) {
+  return payload->IsDataType(type);
+}
+
+ZGUI_API bool zguiImGuiPayload_IsPreview(const ImGuiPayload* payload) {
+  return payload->IsPreview();
+}
+
+ZGUI_API bool zguiImGuiPayload_IsDelivery(const ImGuiPayload* payload) {
+  return payload->IsDelivery();
+}
+
+
 ZGUI_API bool zguiCombo(
     const char* label,
     int* current_item,

--- a/libs/zgui/src/zgui.cpp
+++ b/libs/zgui/src/zgui.cpp
@@ -490,9 +490,6 @@ ZGUI_API const ImGuiPayload* zguiGetDragDropPayload() {
   return ImGui::GetDragDropPayload();
 }
 
-
-ZGUI_API ImGuiPayload zguiImGuiPayload_Init() { return ImGuiPayload(); }
-
 ZGUI_API void zguiImGuiPayload_Clear(ImGuiPayload* payload) { payload->Clear(); }
 
 ZGUI_API bool zguiImGuiPayload_IsDataType(const ImGuiPayload* payload, const char* type) {


### PR DESCRIPTION
This PR adds the ImGui Drag And Drop API, which was missing, to zgui.

I tested some basic functionality (essentially reimplemented the example in `imgui_demo.cpp` [here](https://github.com/ocornut/imgui/blob/master/imgui_demo.cpp#L2353)) and it seems to work.

I'm not sure whether the C++ code is formatted correctly, I did it by hand but I don't know if I'm supposed to run it through some formatter.