### PR TITLE
[zopengl] added debug_output into Capability

### DIFF
--- a/libs/zglfw/src/zglfw.zig
+++ b/libs/zglfw/src/zglfw.zig
@@ -675,6 +675,14 @@ pub const Window = opaque {
         mods: Mods,
     ) callconv(.C) void;
 
+    /// `pub fn setCharCallback(window: *Window, callback: ?CharFn) ?CharFn`
+    pub const setCharCallback = glfwSetCharCallback;
+    extern fn glfwSetCharCallback(window: *Window, callback: ?CharFn) ?CharFn;
+    pub const CharFn = *const fn (
+        window: *Window,
+        codepoint: u32,
+    ) callconv(.C) void;
+
     /// `pub fn setDropCallback(window: *Window, callback: ?DropFn) ?DropFn`
     pub const setDropCallback = glfwSetDropCallback;
     extern fn glfwSetDropCallback(window: *Window, callback: ?DropFn) ?DropFn;
@@ -996,6 +1004,11 @@ fn keyCallback(window: *Window, key: Key, scancode: i32, action: Action, mods: M
     _ = mods;
 }
 
+fn charCallback(window: *Window, codepoint: u32) callconv(.C) void {
+    _ = window;
+    _ = codepoint;
+}
+
 test "zglfw.basic" {
     // TODO: Make this test headless or only skip for CI
     if (true) {
@@ -1044,6 +1057,7 @@ test "zglfw.basic" {
     _ = window.setCursorPosCallback(cursorPosCallback);
     _ = window.setMouseButtonCallback(mouseButtonCallback);
     _ = window.setKeyCallback(keyCallback);
+    _ = window.setCharCallback(charCallback);
     _ = window.setScrollCallback(scrollCallback);
     _ = window.setKeyCallback(null);
 

--- a/libs/zopengl/src/bindings.zig
+++ b/libs/zopengl/src/bindings.zig
@@ -2149,6 +2149,7 @@ pub const DEBUGPROC = *const fn (
     message: [*c]const Char,
     userParam: *const anyopaque,
 ) callconv(.C) void;
+pub const DEBUG_OUTPUT = 0x92E0;
 pub const DEBUG_SOURCE_API = 0x8246;
 pub const DEBUG_SOURCE_WINDOW_SYSTEM = 0x8247;
 pub const DEBUG_SOURCE_SHADER_COMPILER = 0x8248;

--- a/libs/zopengl/src/wrapper.zig
+++ b/libs/zopengl/src/wrapper.zig
@@ -80,6 +80,10 @@ pub fn Wrap(comptime bindings: anytype) type {
             // OpenGL 4.0 (Core Profile)
             //--------------------------------------------------------------------------------------
             sample_shading = SAMPLE_SHADING,
+            //--------------------------------------------------------------------------------------
+            // OpenGL 4.3 (Core Profile)
+            //--------------------------------------------------------------------------------------
+            debug_output = DEBUG_OUTPUT,
         };
 
         pub const StringParamName = enum(Enum) {
@@ -3976,6 +3980,7 @@ pub fn Wrap(comptime bindings: anytype) type {
             message: [*]const u8,
             userParam: ?*const anyopaque,
         ) void;
+        pub const DEBUG_OUTPUT = bindings.DEBUG_OUTPUT;
         pub const DEBUG_SOURCE_API = bindings.DEBUG_SOURCE_API;
         pub const DEBUG_SOURCE_WINDOW_SYSTEM = bindings.DEBUG_SOURCE_WINDOW_SYSTEM;
         pub const DEBUG_SOURCE_SHADER_COMPILER = bindings.DEBUG_SOURCE_SHADER_COMPILER;


### PR DESCRIPTION
Added `debug_output` into `Capability`, and associated constants. Resolves [Issue 489](https://github.com/zig-gamedev/zig-gamedev/issues/489)