### PR TITLE
Add padding for ImGuiWindowFlags 17 value

### DIFF
--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -484,6 +484,7 @@ pub const WindowFlags = packed struct(u32) {
     always_vertical_scrollbar: bool = false,
     always_horizontal_scrollbar: bool = false,
     always_use_window_padding: bool = false,
+    _removed: u1 = 0,
     no_nav_inputs: bool = false,
     no_nav_focus: bool = false,
     unsaved_document: bool = false,


### PR DESCRIPTION
There's a hole in the enumerated values for ImGuiWindowFlags, it skips from `1<<16` to `1<<18`, so anything after always_use_window_padding wasn't working properly. Noticed because `.{ .unsaved_document = true }` wasn't making the dot appear in the title bar.

https://github.com/zig-gamedev/zig-gamedev/blob/73ccc8e894c22319281f6de150e125d2493e703a/libs/zgui/libs/imgui/imgui.h#L975-L976