### PR TITLE
Add shaderStorageBlockBinding support for std430 buffers

### DIFF
--- a/libs/zopengl/src/bindings.zig
+++ b/libs/zopengl/src/bindings.zig
@@ -2663,6 +2663,8 @@ pub const DEBUG_SEVERITY_HIGH = 0x9146;
 pub const DEBUG_SEVERITY_MEDIUM = 0x9147;
 pub const DEBUG_SEVERITY_LOW = 0x9148;
 pub const DEBUG_SEVERITY_NOTIFICATION = 0x826B;
+pub const SHADER_STORAGE_BUFFER = 0x90D2;
+pub const SHADER_STORAGE_BLOCK = 0x92e6;
 
 pub var debugMessageControl: *const fn (
     source: Enum,
@@ -2728,6 +2730,16 @@ pub var getObjectPtrLabel: *const fn (
     bufSize: Sizei,
     length: *Sizei,
     label: [*c]Char,
+) callconv(.C) void = undefined;
+pub var getProgramResourceIndex: *const fn (
+    program: Uint,
+    programInterface: Enum,
+    name: [*c]const Char,
+) callconv(.C) Uint = undefined;
+pub var shaderStorageBlockBinding: *const fn (
+    program: Uint,
+    storageBlockIndex: Uint,
+    storageBlockBinding: Uint,
 ) callconv(.C) void = undefined;
 //--------------------------------------------------------------------------------------------------
 //

--- a/libs/zopengl/src/zopengl.zig
+++ b/libs/zopengl/src/zopengl.zig
@@ -591,6 +591,8 @@ pub fn loadCoreProfile(loader: LoaderFn, major: u32, minor: u32) !void {
         try load("glGetObjectLabel", .{&bindings.getObjectLabel});
         try load("glObjectPtrLabel", .{&bindings.objectPtrLabel});
         try load("glGetObjectPtrLabel", .{&bindings.getObjectPtrLabel});
+        try load("glGetProgramResourceIndex", .{&bindings.getProgramResourceIndex});
+        try load("glShaderStorageBlockBinding", .{&bindings.shaderStorageBlockBinding});
         // TODO
     }
 


### PR DESCRIPTION
shaderStorageBlockBinding 
https://registry.khronos.org/OpenGL-Refpages/gl4/html/glShaderStorageBlockBinding.xhtml

getProgramResourceIndex
https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetProgramResourceIndex.xhtml