### PR TITLE
std.math.atan2 no longer takes a type arg

### DIFF
--- a/samples/instanced_pills_wgpu/src/instanced_pills_wgpu.zig
+++ b/samples/instanced_pills_wgpu/src/instanced_pills_wgpu.zig
@@ -301,7 +301,7 @@ const DemoState = struct {
         const dx = v1[0] - v0[0];
         const dy = v1[1] - v0[1];
         const length = @sqrt(dx * dx + dy * dy);
-        const angle = math.atan2(f32, dy, dx);
+        const angle = math.atan2(dy, dx);
         const position = .{ (v0[0] + v1[0]) / 2.0, (v0[1] + v1[1]) / 2.0 };
         try demo.addPill(.{
             .width = width,


### PR DESCRIPTION
https://ziglang.org/documentation/master/std/#A;std:math.atan2
https://ziglang.org/documentation/master/std/src/std/math/atan2.zig.html#L33

This fixes `zig build instanced_pills_wgpu-run`