### PR TITLE
zflecs: Add a few more functions to the bindings

### DIFF
--- a/libs/zflecs/src/zflecs.zig
+++ b/libs/zflecs/src/zflecs.zig
@@ -2253,6 +2253,31 @@ extern fn ecs_value_init_w_type_info(world: *const world_t, ti: *const type_info
 /// `pub fn progress(world: *world_t, delta_time: ftime_t) bool`
 pub const progress = ecs_progress;
 extern fn ecs_progress(world: *world_t, delta_time: ftime_t) bool;
+
+/// `pub fn set_time_scale(world: *world_t, scale: ftime_t) void`
+pub const set_time_scale = ecs_set_time_scale;
+extern fn ecs_set_time_scale(world: *world_t, scale: ftime_t) void;
+
+/// `pub fn reset_clock(world: *world_t) void`
+pub const reset_clock = ecs_reset_clock;
+extern fn ecs_reset_clock(world: *world_t) void;
+
+/// `pub fn ecs_run_pipeline(world: *world_t, pipeline: entity_t, delta_time: ftime_t) void`
+pub const run_pipeline = ecs_run_pipeline;
+extern fn ecs_run_pipeline(world: *world_t, pipeline: entity_t, delta_time: ftime_t) void;
+
+/// `pub fn ecs_set_threads(world: *world_t, threads: i32) void`
+pub const set_threads = ecs_set_threads;
+extern fn ecs_set_threads(world: *world_t, threads: i32) void;
+
+/// `pub fn ecs_set_task_threads(world: *world_t, task_threads: i32) void`
+pub const set_task_threads = ecs_set_task_threads;
+extern fn ecs_set_task_threads(world: *world_t, task_threads: i32) void;
+
+/// `pub fn ecs_using_task_threads(world: *world_t) bool`
+pub const using_task_threads = ecs_using_task_threads;
+extern fn ecs_using_task_threads(world: *world_t) bool;
+
 //--------------------------------------------------------------------------------------------------
 //
 // Declarative functions (ECS_* macros in flecs)


### PR DESCRIPTION
Need `ecs_set_threads`. Tought I might as well add everything after `ecs_progress` and down from the header