### PR TITLE
wip: fixup zmesh build script to support being used a dependency

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -109,7 +109,7 @@ fn packagesCrossPlatform(b: *std.Build, options: Options) void {
     zpool_pkg = zpool.package(b, target, optimize, .{});
     zglfw_pkg = zglfw.package(b, target, optimize, .{});
     zsdl_pkg = zsdl.package(b, target, optimize, .{});
-    zmesh_pkg = zmesh.package(b, target, optimize, .{});
+    zmesh_pkg = b.dependency("zmesh", .{ .target = target, .optimize = optimize});
     znoise_pkg = znoise.package(b, target, optimize, .{});
     zstbi_pkg = zstbi.package(b, target, optimize, .{});
     zbullet_pkg = zbullet.package(b, target, optimize, .{});
@@ -263,7 +263,7 @@ fn tests(
     test_step.dependOn(zgui.runTests(b, optimize, target));
     test_step.dependOn(zjobs.runTests(b, optimize, target));
     test_step.dependOn(zmath.runTests(b, optimize, target));
-    test_step.dependOn(zmesh.runTests(b, optimize, target));
+    test_step.dependOn(&b.addRunArtifact(zmesh_pkg.artifact("zmesh-tests")).step);
     test_step.dependOn(znoise.runTests(b, optimize, target));
     test_step.dependOn(zopengl.runTests(b, optimize, target));
     test_step.dependOn(zphysics.runTests(b, optimize, target));
@@ -302,7 +302,7 @@ pub var znoise_pkg: znoise.Package = undefined;
 pub var zopengl_pkg: zopengl.Package = undefined;
 pub var zsdl_pkg: zsdl.Package = undefined;
 pub var zpool_pkg: zpool.Package = undefined;
-pub var zmesh_pkg: zmesh.Package = undefined;
+pub var zmesh_pkg: *std.Build.Dependency = undefined;
 pub var zglfw_pkg: zglfw.Package = undefined;
 pub var zstbi_pkg: zstbi.Package = undefined;
 pub var zbullet_pkg: zbullet.Package = undefined;

--- a/samples/bindless/build.zig
+++ b/samples/bindless/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const zstbi_pkg = @import("../../build.zig").zstbi_pkg;
 
     zwin32_pkg.link(exe, .{ .d3d12 = true });
-    zmesh_pkg.link(exe);
+    @import("zmesh").link(zmesh_pkg, exe);
     common_pkg.link(exe);
     zstbi_pkg.link(exe);
     zd3d12_pkg.link(exe);

--- a/samples/bullet_physics_test_wgpu/build.zig
+++ b/samples/bullet_physics_test_wgpu/build.zig
@@ -24,7 +24,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     zgpu_pkg.link(exe);
     zglfw_pkg.link(exe);
     zbullet_pkg.link(exe);
-    zmesh_pkg.link(exe);
+    @import("zmesh").link(zmesh_pkg, exe);
     zmath_pkg.link(exe);
 
     const exe_options = b.addOptions();

--- a/samples/mesh_shader_test/build.zig
+++ b/samples/mesh_shader_test/build.zig
@@ -18,7 +18,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const zmesh_pkg = @import("../../build.zig").zmesh_pkg;
 
     zwin32_pkg.link(exe, .{ .d3d12 = true });
-    zmesh_pkg.link(exe);
+    @import("zmesh").link(zmesh_pkg, exe);
     common_pkg.link(exe);
     zd3d12_pkg.link(exe);
 

--- a/samples/monolith/build.zig
+++ b/samples/monolith/build.zig
@@ -29,7 +29,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     zgui_pkg.link(exe);
     zgpu_pkg.link(exe);
     zglfw_pkg.link(exe);
-    zmesh_pkg.link(exe);
+    @import("zmesh").link(zmesh_pkg, exe);
     zphysics_pkg.link(exe);
 
     const exe_options = b.addOptions();

--- a/samples/physically_based_rendering_wgpu/build.zig
+++ b/samples/physically_based_rendering_wgpu/build.zig
@@ -22,7 +22,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     zgpu_pkg.link(exe);
     zglfw_pkg.link(exe);
     zstbi_pkg.link(exe);
-    zmesh_pkg.link(exe);
+    @import("zmesh").link(zmesh_pkg, exe);
     zmath_pkg.link(exe);
 
     const exe_options = b.addOptions();

--- a/samples/physics_test_wgpu/build.zig
+++ b/samples/physics_test_wgpu/build.zig
@@ -22,7 +22,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     zgui_pkg.link(exe);
     zgpu_pkg.link(exe);
     zglfw_pkg.link(exe);
-    zmesh_pkg.link(exe);
+    @import("zmesh").link(zmesh_pkg, exe);
     zphysics_pkg.link(exe);
 
     const exe_options = b.addOptions();

--- a/samples/procedural_mesh_wgpu/build.zig
+++ b/samples/procedural_mesh_wgpu/build.zig
@@ -24,7 +24,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     znoise_pkg.link(exe);
     ztracy_pkg.link(exe);
     zglfw_pkg.link(exe);
-    zmesh_pkg.link(exe);
+    @import("zmesh").link(zmesh_pkg, exe);
     zmath_pkg.link(exe);
 
     const exe_options = b.addOptions();

--- a/samples/rasterization/build.zig
+++ b/samples/rasterization/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const zmesh_pkg = @import("../../build.zig").zmesh_pkg;
 
     zwin32_pkg.link(exe, .{ .d3d12 = true });
-    zmesh_pkg.link(exe);
+    @import("zmesh").link(zmesh_pkg, exe);
     common_pkg.link(exe);
     zmath_pkg.link(exe);
     zd3d12_pkg.link(exe);


### PR DESCRIPTION
This is just a draft to demonstrate the pattern of changes that I would be making, before proceeding with the rest.

Currently, there is unfortunately a limitation of the build system that requires any artifact that will be accessed via the `Dependency` to be installed. For example, in the zmesh case, this means zmesh.lib and zmesh-tests.exe end up in the zig-out folder. 

There is some discussion about that problem here: https://github.com/ziglang/zig/pull/19017#issuecomment-1975193399 and here: https://discord.com/channels/605571803288698900/1145919498801655839/1213910624841506857.

I may hold on off proceeding with these changes until that's cleared up.