### PR TITLE
Fixes for path issues on Windows.

### DIFF
--- a/libs/zbullet/build.zig
+++ b/libs/zbullet/build.zig
@@ -17,7 +17,7 @@ pub fn package(
     _: struct {},
 ) Package {
     const zbullet = b.addModule("zbullet", .{
-        .root_source_file = .{ .path = thisDir() ++ "/src/zbullet.zig" },
+        .root_source_file = .{ .cwd_relative = thisDir() ++ "/src/zbullet.zig" },
     });
 
     const zbullet_c_cpp = b.addStaticLibrary(.{
@@ -26,8 +26,8 @@ pub fn package(
         .optimize = optimize,
     });
 
-    zbullet_c_cpp.addIncludePath(.{ .path = thisDir() ++ "/libs/cbullet" });
-    zbullet_c_cpp.addIncludePath(.{ .path = thisDir() ++ "/libs/bullet" });
+    zbullet_c_cpp.addIncludePath(.{ .cwd_relative = thisDir() ++ "/libs/cbullet" });
+    zbullet_c_cpp.addIncludePath(.{ .cwd_relative = thisDir() ++ "/libs/bullet" });
     zbullet_c_cpp.linkLibC();
     zbullet_c_cpp.linkLibCpp();
 
@@ -39,11 +39,12 @@ pub fn package(
         "-fno-sanitize=undefined",
     };
     zbullet_c_cpp.addCSourceFiles(.{
+        .root = .{ .cwd_relative = thisDir() },
         .files = &.{
-            thisDir() ++ "/libs/cbullet/cbullet.cpp",
-            thisDir() ++ "/libs/bullet/btLinearMathAll.cpp",
-            thisDir() ++ "/libs/bullet/btBulletCollisionAll.cpp",
-            thisDir() ++ "/libs/bullet/btBulletDynamicsAll.cpp",
+            "libs/cbullet/cbullet.cpp",
+            "libs/bullet/btLinearMathAll.cpp",
+            "libs/bullet/btBulletCollisionAll.cpp",
+            "libs/bullet/btBulletDynamicsAll.cpp",
         },
         .flags = flags,
     });
@@ -73,7 +74,7 @@ pub fn runTests(
 
     var tests = b.addTest(.{
         .name = "zbullet-tests",
-        .root_source_file = .{ .path = thisDir() ++ "/src/zbullet.zig" },
+        .root_source_file = .{ .cwd_relative = thisDir() ++ "/src/zbullet.zig" },
         .target = target,
         .optimize = optimize,
     });

--- a/libs/zglfw/build.zig
+++ b/libs/zglfw/build.zig
@@ -58,7 +58,7 @@ pub fn package(
     step.addOption(bool, "shared", args.options.shared);
 
     const zglfw = b.addModule("zglfw", .{
-        .root_source_file = .{ .path = thisDir() ++ "/src/zglfw.zig" },
+        .root_source_file = .{ .cwd_relative = thisDir() ++ "/src/zglfw.zig" },
     });
 
     const zglfw_c_cpp = if (args.options.shared) blk: {
@@ -79,7 +79,7 @@ pub fn package(
         .optimize = optimize,
     });
 
-    zglfw_c_cpp.addIncludePath(.{ .path = thisDir() ++ "/libs/glfw/include" });
+    zglfw_c_cpp.addIncludePath(.{ .cwd_relative = thisDir() ++ "/libs/glfw/include" });
     zglfw_c_cpp.linkLibC();
 
     const system_sdk = b.dependency("system_sdk", .{});
@@ -91,28 +91,29 @@ pub fn package(
             zglfw_c_cpp.linkSystemLibrary("user32");
             zglfw_c_cpp.linkSystemLibrary("shell32");
             zglfw_c_cpp.addCSourceFiles(.{
+                .root = .{ .cwd_relative = src_dir },
                 .files = &.{
-                    src_dir ++ "platform.c",
-                    src_dir ++ "monitor.c",
-                    src_dir ++ "init.c",
-                    src_dir ++ "vulkan.c",
-                    src_dir ++ "input.c",
-                    src_dir ++ "context.c",
-                    src_dir ++ "window.c",
-                    src_dir ++ "osmesa_context.c",
-                    src_dir ++ "egl_context.c",
-                    src_dir ++ "null_init.c",
-                    src_dir ++ "null_monitor.c",
-                    src_dir ++ "null_window.c",
-                    src_dir ++ "null_joystick.c",
-                    src_dir ++ "wgl_context.c",
-                    src_dir ++ "win32_thread.c",
-                    src_dir ++ "win32_init.c",
-                    src_dir ++ "win32_monitor.c",
-                    src_dir ++ "win32_time.c",
-                    src_dir ++ "win32_joystick.c",
-                    src_dir ++ "win32_window.c",
-                    src_dir ++ "win32_module.c",
+                    "platform.c",
+                    "monitor.c",
+                    "init.c",
+                    "vulkan.c",
+                    "input.c",
+                    "context.c",
+                    "window.c",
+                    "osmesa_context.c",
+                    "egl_context.c",
+                    "null_init.c",
+                    "null_monitor.c",
+                    "null_window.c",
+                    "null_joystick.c",
+                    "wgl_context.c",
+                    "win32_thread.c",
+                    "win32_init.c",
+                    "win32_monitor.c",
+                    "win32_time.c",
+                    "win32_joystick.c",
+                    "win32_window.c",
+                    "win32_module.c",
                 },
                 .flags = &.{"-D_GLFW_WIN32"},
             });
@@ -134,29 +135,30 @@ pub fn package(
             zglfw_c_cpp.linkFramework("CoreGraphics");
             zglfw_c_cpp.linkFramework("Foundation");
             zglfw_c_cpp.addCSourceFiles(.{
+                .root = .{ .cwd_relative = src_dir },
                 .files = &.{
-                    src_dir ++ "platform.c",
-                    src_dir ++ "monitor.c",
-                    src_dir ++ "init.c",
-                    src_dir ++ "vulkan.c",
-                    src_dir ++ "input.c",
-                    src_dir ++ "context.c",
-                    src_dir ++ "window.c",
-                    src_dir ++ "osmesa_context.c",
-                    src_dir ++ "egl_context.c",
-                    src_dir ++ "null_init.c",
-                    src_dir ++ "null_monitor.c",
-                    src_dir ++ "null_window.c",
-                    src_dir ++ "null_joystick.c",
-                    src_dir ++ "posix_thread.c",
-                    src_dir ++ "posix_module.c",
-                    src_dir ++ "posix_poll.c",
-                    src_dir ++ "nsgl_context.m",
-                    src_dir ++ "cocoa_time.c",
-                    src_dir ++ "cocoa_joystick.m",
-                    src_dir ++ "cocoa_init.m",
-                    src_dir ++ "cocoa_window.m",
-                    src_dir ++ "cocoa_monitor.m",
+                    "platform.c",
+                    "monitor.c",
+                    "init.c",
+                    "vulkan.c",
+                    "input.c",
+                    "context.c",
+                    "window.c",
+                    "osmesa_context.c",
+                    "egl_context.c",
+                    "null_init.c",
+                    "null_monitor.c",
+                    "null_window.c",
+                    "null_joystick.c",
+                    "posix_thread.c",
+                    "posix_module.c",
+                    "posix_poll.c",
+                    "nsgl_context.m",
+                    "cocoa_time.c",
+                    "cocoa_joystick.m",
+                    "cocoa_init.m",
+                    "cocoa_window.m",
+                    "cocoa_monitor.m",
                 },
                 .flags = &.{"-D_GLFW_COCOA"},
             });
@@ -176,31 +178,32 @@ pub fn package(
             }
             zglfw_c_cpp.linkSystemLibrary("X11");
             zglfw_c_cpp.addCSourceFiles(.{
+                .root = .{ .cwd_relative = src_dir },
                 .files = &.{
-                    src_dir ++ "platform.c",
-                    src_dir ++ "monitor.c",
-                    src_dir ++ "init.c",
-                    src_dir ++ "vulkan.c",
-                    src_dir ++ "input.c",
-                    src_dir ++ "context.c",
-                    src_dir ++ "window.c",
-                    src_dir ++ "osmesa_context.c",
-                    src_dir ++ "egl_context.c",
-                    src_dir ++ "null_init.c",
-                    src_dir ++ "null_monitor.c",
-                    src_dir ++ "null_window.c",
-                    src_dir ++ "null_joystick.c",
-                    src_dir ++ "posix_time.c",
-                    src_dir ++ "posix_thread.c",
-                    src_dir ++ "posix_module.c",
-                    src_dir ++ "posix_poll.c",
-                    src_dir ++ "egl_context.c",
-                    src_dir ++ "glx_context.c",
-                    src_dir ++ "linux_joystick.c",
-                    src_dir ++ "xkb_unicode.c",
-                    src_dir ++ "x11_init.c",
-                    src_dir ++ "x11_window.c",
-                    src_dir ++ "x11_monitor.c",
+                    "platform.c",
+                    "monitor.c",
+                    "init.c",
+                    "vulkan.c",
+                    "input.c",
+                    "context.c",
+                    "window.c",
+                    "osmesa_context.c",
+                    "egl_context.c",
+                    "null_init.c",
+                    "null_monitor.c",
+                    "null_window.c",
+                    "null_joystick.c",
+                    "posix_time.c",
+                    "posix_thread.c",
+                    "posix_module.c",
+                    "posix_poll.c",
+                    "egl_context.c",
+                    "glx_context.c",
+                    "linux_joystick.c",
+                    "xkb_unicode.c",
+                    "x11_init.c",
+                    "x11_window.c",
+                    "x11_monitor.c",
                 },
                 .flags = &.{"-D_GLFW_X11"},
             });
@@ -232,7 +235,7 @@ pub fn runTests(
 ) *std.Build.Step {
     const tests = b.addTest(.{
         .name = "zglfw-tests",
-        .root_source_file = .{ .path = thisDir() ++ "/src/zglfw.zig" },
+        .root_source_file = .{ .cwd_relative = thisDir() ++ "/src/zglfw.zig" },
         .target = target,
         .optimize = optimize,
     });
@@ -240,7 +243,7 @@ pub fn runTests(
     const zglfw_pkg = package(b, target, optimize, .{});
     zglfw_pkg.link(tests);
 
-    tests.addIncludePath(.{ .path = thisDir() ++ "/libs/glfw/include" });
+    tests.addIncludePath(.{ .cwd_relative = thisDir() ++ "/libs/glfw/include" });
     switch (target.result.os.tag) {
         .linux => {
             tests.addSystemIncludePath(.{

--- a/libs/zgui/build.zig
+++ b/libs/zgui/build.zig
@@ -50,7 +50,7 @@ pub fn package(
     const zgui_options = step.createModule();
 
     const zgui = b.addModule("zgui", .{
-        .root_source_file = .{ .path = thisDir() ++ "/src/gui.zig" },
+        .root_source_file = .{ .cwd_relative = thisDir() ++ "/src/gui.zig" },
         .imports = &.{
             .{ .name = "zgui_options", .module = zgui_options },
         },
@@ -81,8 +81,8 @@ pub fn package(
         .optimize = optimize,
     });
 
-    zgui_c_cpp.addIncludePath(.{ .path = thisDir() ++ "/libs" });
-    zgui_c_cpp.addIncludePath(.{ .path = thisDir() ++ "/libs/imgui" });
+    zgui_c_cpp.addIncludePath(.{ .cwd_relative = thisDir() ++ "/libs" });
+    zgui_c_cpp.addIncludePath(.{ .cwd_relative = thisDir() ++ "/libs/imgui" });
 
     const abi = target.result.abi;
     zgui_c_cpp.linkLibC();
@@ -92,18 +92,19 @@ pub fn package(
     const cflags = &.{"-fno-sanitize=undefined"};
 
     zgui_c_cpp.addCSourceFile(.{
-        .file = .{ .path = thisDir() ++ "/src/zgui.cpp" },
+        .file = .{ .cwd_relative = thisDir() ++ "/src/zgui.cpp" },
         .flags = cflags,
     });
 
     if (args.options.with_imgui) {
         zgui_c_cpp.addCSourceFiles(.{
+            .root = .{ .cwd_relative = thisDir() },
             .files = &.{
-                thisDir() ++ "/libs/imgui/imgui.cpp",
-                thisDir() ++ "/libs/imgui/imgui_widgets.cpp",
-                thisDir() ++ "/libs/imgui/imgui_tables.cpp",
-                thisDir() ++ "/libs/imgui/imgui_draw.cpp",
-                thisDir() ++ "/libs/imgui/imgui_demo.cpp",
+                "libs/imgui/imgui.cpp",
+                "libs/imgui/imgui_widgets.cpp",
+                "libs/imgui/imgui_tables.cpp",
+                "libs/imgui/imgui_draw.cpp",
+                "libs/imgui/imgui_demo.cpp",
             },
             .flags = cflags,
         });
@@ -112,10 +113,11 @@ pub fn package(
     if (args.options.with_implot) {
         zgui_c_cpp.defineCMacro("ZGUI_IMPLOT", "1");
         zgui_c_cpp.addCSourceFiles(.{
+            .root = .{ .cwd_relative = thisDir() },
             .files = &.{
-                thisDir() ++ "/libs/imgui/implot_demo.cpp",
-                thisDir() ++ "/libs/imgui/implot.cpp",
-                thisDir() ++ "/libs/imgui/implot_items.cpp",
+                "libs/imgui/implot_demo.cpp",
+                "libs/imgui/implot.cpp",
+                "libs/imgui/implot_items.cpp",
             },
             .flags = cflags,
         });
@@ -127,12 +129,13 @@ pub fn package(
         .glfw_wgpu => {
             const zglfw = b.dependency("zglfw", .{});
             const zgpu = b.dependency("zgpu", .{});
-            zgui_c_cpp.addIncludePath(.{ .path = zglfw.path("libs/glfw/include").getPath(b) });
-            zgui_c_cpp.addIncludePath(.{ .path = zgpu.path("libs/dawn/include").getPath(b) });
+            zgui_c_cpp.addIncludePath(.{ .cwd_relative = zglfw.path("libs/glfw/include").getPath(b) });
+            zgui_c_cpp.addIncludePath(.{ .cwd_relative = zgpu.path("libs/dawn/include").getPath(b) });
             zgui_c_cpp.addCSourceFiles(.{
+                .root = .{ .cwd_relative = thisDir() },
                 .files = &.{
-                    thisDir() ++ "/libs/imgui/backends/imgui_impl_glfw.cpp",
-                    thisDir() ++ "/libs/imgui/backends/imgui_impl_wgpu.cpp",
+                    "libs/imgui/backends/imgui_impl_glfw.cpp",
+                    "libs/imgui/backends/imgui_impl_wgpu.cpp",
                 },
                 .flags = cflags,
             });
@@ -141,18 +144,20 @@ pub fn package(
             const zglfw = b.dependency("zglfw", .{});
             zgui_c_cpp.addIncludePath(.{ .path = zglfw.path("libs/glfw/include").getPath(b) });
             zgui_c_cpp.addCSourceFiles(.{
+                .root = .{ .cwd_relative = thisDir() },
                 .files = &.{
-                    thisDir() ++ "/libs/imgui/backends/imgui_impl_glfw.cpp",
-                    thisDir() ++ "/libs/imgui/backends/imgui_impl_opengl3.cpp",
+                    "libs/imgui/backends/imgui_impl_glfw.cpp",
+                    "libs/imgui/backends/imgui_impl_opengl3.cpp",
                 },
                 .flags = &(cflags.* ++ .{"-DIMGUI_IMPL_OPENGL_LOADER_CUSTOM"}),
             });
         },
         .win32_dx12 => {
             zgui_c_cpp.addCSourceFiles(.{
+                .root = .{ .cwd_relative = thisDir() },
                 .files = &.{
-                    thisDir() ++ "/libs/imgui/backends/imgui_impl_win32.cpp",
-                    thisDir() ++ "/libs/imgui/backends/imgui_impl_dx12.cpp",
+                    "libs/imgui/backends/imgui_impl_win32.cpp",
+                    "libs/imgui/backends/imgui_impl_dx12.cpp",
                 },
                 .flags = cflags,
             });
@@ -206,7 +211,7 @@ pub fn runTests(
 ) *std.Build.Step {
     const gui_tests = b.addTest(.{
         .name = "gui-tests",
-        .root_source_file = .{ .path = thisDir() ++ "/src/gui.zig" },
+        .root_source_file = .{ .cwd_relative = thisDir() ++ "/src/gui.zig" },
         .target = target,
         .optimize = optimize,
     });

--- a/libs/zgui/src/backend_glfw_opengl.zig
+++ b/libs/zgui/src/backend_glfw_opengl.zig
@@ -8,7 +8,7 @@ pub fn initWithGlSlVersion(
         unreachable;
     }
 
-    ImGui_ImplOpenGL3_Init(@ptrCast(glsl_version));
+    ImGui_ImplOpenGL3_Init(if (glsl_version) |version| @ptrCast(version) else null);
 }
 
 pub fn init(

--- a/libs/zmesh/build.zig
+++ b/libs/zmesh/build.zig
@@ -68,30 +68,31 @@ pub fn package(
     else
         "-DPAR_SHAPES_T=uint16_t";
 
-    zmesh_c_cpp.addIncludePath(.{ .path = thisDir() ++ "/libs/par_shapes" });
+    zmesh_c_cpp.addIncludePath(.{ .cwd_relative = thisDir() ++ "/libs/par_shapes" });
     zmesh_c_cpp.addCSourceFile(.{
-        .file = .{ .path = thisDir() ++ "/libs/par_shapes/par_shapes.c" },
+        .file = .{ .cwd_relative = thisDir() ++ "/libs/par_shapes/par_shapes.c" },
         .flags = &.{ "-std=c99", "-fno-sanitize=undefined", par_shapes_t },
     });
 
     zmesh_c_cpp.addCSourceFiles(.{
+        .root = .{ .cwd_relative = thisDir() },
         .files = &.{
-            thisDir() ++ "/libs/meshoptimizer/clusterizer.cpp",
-            thisDir() ++ "/libs/meshoptimizer/indexgenerator.cpp",
-            thisDir() ++ "/libs/meshoptimizer/vcacheoptimizer.cpp",
-            thisDir() ++ "/libs/meshoptimizer/vcacheanalyzer.cpp",
-            thisDir() ++ "/libs/meshoptimizer/vfetchoptimizer.cpp",
-            thisDir() ++ "/libs/meshoptimizer/vfetchanalyzer.cpp",
-            thisDir() ++ "/libs/meshoptimizer/overdrawoptimizer.cpp",
-            thisDir() ++ "/libs/meshoptimizer/overdrawanalyzer.cpp",
-            thisDir() ++ "/libs/meshoptimizer/simplifier.cpp",
-            thisDir() ++ "/libs/meshoptimizer/allocator.cpp",
+            "libs/meshoptimizer/clusterizer.cpp",
+            "libs/meshoptimizer/indexgenerator.cpp",
+            "libs/meshoptimizer/vcacheoptimizer.cpp",
+            "libs/meshoptimizer/vcacheanalyzer.cpp",
+            "libs/meshoptimizer/vfetchoptimizer.cpp",
+            "libs/meshoptimizer/vfetchanalyzer.cpp",
+            "libs/meshoptimizer/overdrawoptimizer.cpp",
+            "libs/meshoptimizer/overdrawanalyzer.cpp",
+            "libs/meshoptimizer/simplifier.cpp",
+            "libs/meshoptimizer/allocator.cpp",
         },
         .flags = &.{""},
     });
-    zmesh_c_cpp.addIncludePath(.{ .path = thisDir() ++ "/libs/cgltf" });
+    zmesh_c_cpp.addIncludePath(.{ .cwd_relative = thisDir() ++ "/libs/cgltf" });
     zmesh_c_cpp.addCSourceFile(.{
-        .file = .{ .path = thisDir() ++ "/libs/cgltf/cgltf.c" },
+        .file = .{ .cwd_relative = thisDir() ++ "/libs/cgltf/cgltf.c" },
         .flags = &.{"-std=c99"},
     });
 
@@ -125,12 +126,12 @@ pub fn runTests(
 ) *std.Build.Step {
     const tests = b.addTest(.{
         .name = "zmesh-tests",
-        .root_source_file = .{ .path = thisDir() ++ "/src/main.zig" },
+        .root_source_file = .{ .cwd_relative = thisDir() ++ "/src/main.zig" },
         .target = target,
         .optimize = optimize,
     });
 
-    tests.addIncludePath(.{ .path = thisDir() ++ "/libs/cgltf" });
+    tests.addIncludePath(.{ .cwd_relative = thisDir() ++ "/libs/cgltf" });
 
     const zmesh_pkg = package(b, target, optimize, .{});
     zmesh_pkg.link(tests);

--- a/libs/zphysics/build.zig
+++ b/libs/zphysics/build.zig
@@ -14,7 +14,7 @@ pub const Package = struct {
     zphysics_c_cpp: *std.Build.Step.Compile,
 
     pub fn link(pkg: Package, exe: *std.Build.Step.Compile) void {
-        exe.addIncludePath(.{ .path = thisDir() ++ "/libs/JoltC" });
+        exe.addIncludePath(.{ .cwd_relative = thisDir() ++ "/libs/JoltC" });
         exe.linkLibrary(pkg.zphysics_c_cpp);
         exe.root_module.addImport("zphysics", pkg.zphysics);
         exe.root_module.addImport("zphysics_options", pkg.zphysics_options);
@@ -38,14 +38,14 @@ pub fn package(
     const zphysics_options = step.createModule();
 
     const zphysics = b.addModule("zphysics", .{
-        .root_source_file = .{ .path = thisDir() ++ "/src/zphysics.zig" },
+        .root_source_file = .{ .cwd_relative = thisDir() ++ "/src/zphysics.zig" },
         .imports = &.{
             .{ .name = "zphysics_options", .module = zphysics_options },
         },
     });
 
-    zphysics.addIncludePath(.{ .path = thisDir() ++ "/libs" });
-    zphysics.addIncludePath(.{ .path = thisDir() ++ "/libs/JoltC" });
+    zphysics.addIncludePath(.{ .cwd_relative = thisDir() ++ "/libs" });
+    zphysics.addIncludePath(.{ .cwd_relative = thisDir() ++ "/libs/JoltC" });
 
     const zphysics_c_cpp = b.addStaticLibrary(.{
         .name = "zphysics",
@@ -53,8 +53,8 @@ pub fn package(
         .optimize = optimize,
     });
 
-    zphysics_c_cpp.addIncludePath(.{ .path = thisDir() ++ "/libs" });
-    zphysics_c_cpp.addIncludePath(.{ .path = thisDir() ++ "/libs/JoltC" });
+    zphysics_c_cpp.addIncludePath(.{ .cwd_relative = thisDir() ++ "/libs" });
+    zphysics_c_cpp.addIncludePath(.{ .cwd_relative = thisDir() ++ "/libs/JoltC" });
     zphysics_c_cpp.linkLibC();
     if (target.result.abi != .msvc)
         zphysics_c_cpp.linkLibCpp();
@@ -70,11 +70,12 @@ pub fn package(
         "-fno-sanitize=undefined",
     };
 
-    const src_dir = thisDir() ++ "/libs/Jolt";
+    const src_dir = "libs/Jolt";
     zphysics_c_cpp.addCSourceFiles(.{
+        .root = .{ .cwd_relative = thisDir() },
         .files = &.{
-            thisDir() ++ "/libs/JoltC/JoltPhysicsC.cpp",
-            thisDir() ++ "/libs/JoltC/JoltPhysicsC_Extensions.cpp",
+            "libs/JoltC/JoltPhysicsC.cpp",
+            "libs/JoltC/JoltPhysicsC_Extensions.cpp",
             src_dir ++ "/AABBTree/AABBTreeBuilder.cpp",
             src_dir ++ "/Core/Color.cpp",
             src_dir ++ "/Core/Factory.cpp",
@@ -266,7 +267,7 @@ fn testStep(
 ) *std.Build.Step.Run {
     const test_exe = b.addTest(.{
         .name = name,
-        .root_source_file = .{ .path = thisDir() ++ "/src/zphysics.zig" },
+        .root_source_file = .{ .cwd_relative = thisDir() ++ "/src/zphysics.zig" },
         .target = target,
         .optimize = optimize,
     });
@@ -277,7 +278,7 @@ fn testStep(
     }
 
     test_exe.addCSourceFile(.{
-        .file = .{ .path = thisDir() ++ "/libs/JoltC/JoltPhysicsC_Tests.c" },
+        .file = .{ .cwd_relative = thisDir() ++ "/libs/JoltC/JoltPhysicsC_Tests.c" },
         .flags = &.{
             "-std=c11",
             if (target.result.abi != .msvc) "-DJPH_COMPILER_MINGW" else "",

--- a/samples/instanced_pills_wgpu/src/instanced_pills_wgpu.zig
+++ b/samples/instanced_pills_wgpu/src/instanced_pills_wgpu.zig
@@ -301,7 +301,7 @@ const DemoState = struct {
         const dx = v1[0] - v0[0];
         const dy = v1[1] - v0[1];
         const length = @sqrt(dx * dx + dy * dy);
-        const angle = math.atan2(f32, dy, dx);
+        const angle = math.atan2(dy, dx);
         const position = .{ (v0[0] + v1[0]) / 2.0, (v0[1] + v1[1]) / 2.0 };
         try demo.addPill(.{
             .width = width,


### PR DESCRIPTION
Fixes https://github.com/zig-gamedev/zig-gamedev/issues/511.

This is an alternative to the solution here https://github.com/zig-gamedev/zig-gamedev/pull/514, which can be used until the issues with the build system preventing dependency use are resolved.

Changes:
- Change build scripts to use `cwd_relative` when `thisDIr()` is used
- FIxup atan2 usage in instanced_pills_wgpu
- Fixup @ptrCast of optional slice causing a compiler panic (https://github.com/ziglang/zig/issues/19168)