### PR TITLE
added zgui glfw+dx12 backend and sample

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -119,6 +119,9 @@ fn packagesCrossPlatform(b: *std.Build, options: Options) void {
     zgui_glfw_gl_pkg = zgui.package(b, target, optimize, .{
         .options = .{ .backend = .glfw_opengl3 },
     });
+    zgui_glfw_d3d12_pkg = zgui.package(b, target, optimize, .{
+        .options = .{ .backend = .glfw_dx12 },
+    });
     zgpu_pkg = zgpu.package(b, target, optimize, .{
         .options = .{},
         .deps = .{ .zpool = zpool_pkg },
@@ -219,6 +222,7 @@ fn samples(b: *std.Build, options: Options) void {
 fn samplesWindowsLinux(b: *std.Build, options: Options) void {
     const minimal_d3d12 = @import("samples/minimal_d3d12/build.zig");
     const minimal_glfw_d3d12 = @import("samples/minimal_glfw_d3d12/build.zig");
+    const minimal_zgui_glfw_d3d12 = @import("samples/minimal_zgui_glfw_d3d12/build.zig");
     const textured_quad = @import("samples/textured_quad/build.zig");
     const triangle = @import("samples/triangle/build.zig");
     const mesh_shader_test = @import("samples/mesh_shader_test/build.zig");
@@ -228,6 +232,7 @@ fn samplesWindowsLinux(b: *std.Build, options: Options) void {
 
     install(b, minimal_d3d12.build(b, options), "minimal_d3d12");
     install(b, minimal_glfw_d3d12.build(b, options), "minimal_glfw_d3d12");
+    install(b, minimal_zgui_glfw_d3d12.build(b, options), "minimal_zgui_glfw_d3d12");
     install(b, bindless.build(b, options), "bindless");
     install(b, triangle.build(b, options), "triangle");
     //install(b, simple_raytracer.build(b, options), "simple_raytracer");
@@ -310,6 +315,7 @@ pub var zstbi_pkg: zstbi.Package = undefined;
 pub var zbullet_pkg: zbullet.Package = undefined;
 pub var zgui_glfw_wgpu_pkg: zgui.Package = undefined;
 pub var zgui_glfw_gl_pkg: zgui.Package = undefined;
+pub var zgui_glfw_d3d12_pkg: zgui.Package = undefined;
 pub var zgpu_pkg: zgpu.Package = undefined;
 pub var ztracy_pkg: ztracy.Package = undefined;
 pub var zphysics_pkg: zphysics.Package = undefined;

--- a/libs/zgui/build.zig
+++ b/libs/zgui/build.zig
@@ -4,6 +4,7 @@ pub const Backend = enum {
     no_backend,
     glfw_wgpu,
     glfw_opengl3,
+    glfw_dx12,
     win32_dx12,
 };
 
@@ -147,6 +148,18 @@ pub fn package(
                 },
                 .flags = &(cflags.* ++ .{"-DIMGUI_IMPL_OPENGL_LOADER_CUSTOM"}),
             });
+        },
+        .glfw_dx12 => {
+            const zglfw = b.dependency("zglfw", .{});
+            zgui_c_cpp.addIncludePath(.{ .path = zglfw.path("libs/glfw/include").getPath(b) });
+            zgui_c_cpp.addCSourceFiles(.{
+                .files = &.{
+                    thisDir() ++ "/libs/imgui/backends/imgui_impl_glfw.cpp",
+                    thisDir() ++ "/libs/imgui/backends/imgui_impl_dx12.cpp",
+                },
+                .flags = cflags,
+            });
+            zgui_c_cpp.linkSystemLibrary("d3dcompiler_47");
         },
         .win32_dx12 => {
             zgui_c_cpp.addCSourceFiles(.{

--- a/libs/zgui/src/backend_glfw_dx12.zig
+++ b/libs/zgui/src/backend_glfw_dx12.zig
@@ -1,0 +1,74 @@
+const gui = @import("gui.zig");
+
+pub fn init(
+    window: *const anyopaque, // zglfw.Window
+    device: *const anyopaque, // ID3D12Device
+    num_frames_in_flight: u32,
+    rtv_format: c_uint, // DXGI_FORMAT
+    cbv_srv_heap: *const anyopaque, // ID3D12DescriptorHeap
+    font_srv_cpu_desc_handle: D3D12_CPU_DESCRIPTOR_HANDLE,
+    font_srv_gpu_desc_handle: D3D12_GPU_DESCRIPTOR_HANDLE,
+) void {
+    if (!ImGui_ImplGlfw_InitForOther(window, true)) {
+        @panic("failed to init glfw for imgui");
+    }
+
+    if (!ImGui_ImplDX12_Init(
+        device,
+        num_frames_in_flight,
+        rtv_format,
+        cbv_srv_heap,
+        font_srv_cpu_desc_handle,
+        font_srv_gpu_desc_handle,
+    )) {
+        @panic("failed to init d3d12 for imgui");
+    }
+}
+
+pub fn deinit() void {
+    ImGui_ImplGlfw_Shutdown();
+    ImGui_ImplDX12_Shutdown();
+}
+
+pub fn newFrame(fb_width: u32, fb_height: u32) void {
+    ImGui_ImplGlfw_NewFrame();
+    ImGui_ImplDX12_NewFrame();
+
+    gui.io.setDisplaySize(@as(f32, @floatFromInt(fb_width)), @as(f32, @floatFromInt(fb_height)));
+    gui.io.setDisplayFramebufferScale(1.0, 1.0);
+
+    gui.newFrame();
+}
+
+pub fn draw(
+    graphics_command_list: *const anyopaque, // *ID3D12GraphicsCommandList
+) void {
+    gui.render();
+    ImGui_ImplDX12_RenderDrawData(gui.getDrawData(), graphics_command_list);
+}
+
+pub const D3D12_CPU_DESCRIPTOR_HANDLE = extern struct {
+    ptr: c_ulonglong,
+};
+
+pub const D3D12_GPU_DESCRIPTOR_HANDLE = extern struct {
+    ptr: c_ulonglong,
+};
+
+extern fn ImGui_ImplGlfw_InitForOther(window: *const anyopaque, install_callbacks: bool) bool;
+extern fn ImGui_ImplGlfw_NewFrame() void;
+extern fn ImGui_ImplGlfw_Shutdown() void;
+extern fn ImGui_ImplDX12_Init(
+    device: *const anyopaque, // ID3D12Device
+    num_frames_in_flight: u32,
+    rtv_format: u32, // DXGI_FORMAT
+    cbv_srv_heap: *const anyopaque, // ID3D12DescriptorHeap
+    font_srv_cpu_desc_handle: D3D12_CPU_DESCRIPTOR_HANDLE,
+    font_srv_gpu_desc_handle: D3D12_GPU_DESCRIPTOR_HANDLE,
+) bool;
+extern fn ImGui_ImplDX12_Shutdown() void;
+extern fn ImGui_ImplDX12_NewFrame() void;
+extern fn ImGui_ImplDX12_RenderDrawData(
+    draw_data: *const anyopaque, // *ImDrawData
+    graphics_command_list: *const anyopaque, // *ID3D12GraphicsCommandList
+) void;

--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -8,6 +8,7 @@ pub const plot = @import("plot.zig");
 pub const backend = switch (@import("zgui_options").backend) {
     .glfw_wgpu => @import("backend_glfw_wgpu.zig"),
     .glfw_opengl3 => @import("backend_glfw_opengl.zig"),
+    .glfw_dx12 => @import("backend_glfw_dx12.zig"),
     .win32_dx12 => .{}, // TODO:
     .no_backend => .{},
 };

--- a/samples/minimal_zgui_glfw_d3d12/README.md
+++ b/samples/minimal_zgui_glfw_d3d12/README.md
@@ -1,0 +1,3 @@
+## minimal zgui with glfw d3d12 backend
+
+This minimal sample has a button that prints a message to the console when pressed.

--- a/samples/minimal_zgui_glfw_d3d12/build.zig
+++ b/samples/minimal_zgui_glfw_d3d12/build.zig
@@ -1,0 +1,42 @@
+const std = @import("std");
+
+const Options = @import("../../build.zig").Options;
+
+const demo_name = "minimal_zgui_glfw_d3d12";
+const content_dir = demo_name ++ "_content/";
+
+pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
+    const exe = b.addExecutable(.{
+        .name = demo_name,
+        .root_source_file = .{ .path = thisDir() ++ "/src/" ++ demo_name ++ ".zig" },
+        .target = options.target,
+        .optimize = options.optimize,
+    });
+
+    const zgui_pkg = @import("../../build.zig").zgui_glfw_d3d12_pkg;
+    const zd3d12_pkg = @import("../../build.zig").zd3d12_pkg;
+    const zwin32_pkg = @import("../../build.zig").zwin32_pkg;
+    const zglfw_pkg = @import("../../build.zig").zglfw_pkg;
+
+    zgui_pkg.link(exe);
+    zd3d12_pkg.link(exe);
+    zwin32_pkg.link(exe, .{ .d3d12 = true });
+    zglfw_pkg.link(exe);
+
+    const exe_options = b.addOptions();
+    exe.root_module.addOptions("build_options", exe_options);
+    exe_options.addOption([]const u8, "content_dir", content_dir);
+
+    const install_content_step = b.addInstallDirectory(.{
+        .source_dir = .{ .path = thisDir() ++ "/" ++ content_dir },
+        .install_dir = .{ .custom = "" },
+        .install_subdir = "bin/" ++ content_dir,
+    });
+    exe.step.dependOn(&install_content_step.step);
+
+    return exe;
+}
+
+inline fn thisDir() []const u8 {
+    return comptime std.fs.path.dirname(@src().file) orelse ".";
+}

--- a/samples/minimal_zgui_glfw_d3d12/minimal_zgui_glfw_d3d12_content/Roboto-Medium.ttf
+++ b/samples/minimal_zgui_glfw_d3d12/minimal_zgui_glfw_d3d12_content/Roboto-Medium.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8559132c89ad51d8a2ba5b171887a44a7ba93776e205f553573de228e64b45f8
+size 162588

--- a/samples/minimal_zgui_glfw_d3d12/src/minimal_zgui_glfw_d3d12.zig
+++ b/samples/minimal_zgui_glfw_d3d12/src/minimal_zgui_glfw_d3d12.zig
@@ -1,0 +1,131 @@
+const std = @import("std");
+const zgui = @import("zgui");
+const glfw = @import("zglfw");
+const zwin32 = @import("zwin32");
+const zd3d12 = @import("zd3d12");
+const w32 = zwin32.w32;
+const d3d12 = zwin32.d3d12;
+const dxgi = zwin32.dxgi;
+
+pub export const D3D12SDKVersion: u32 = 610;
+pub export const D3D12SDKPath: [*:0]const u8 = ".\\d3d12\\";
+
+const content_dir = @import("build_options").content_dir;
+
+const window_name = "zig-gamedev: minimal imgui glfw d3d12";
+
+pub fn main() !void {
+    // Change current working directory to where the executable is located.
+    {
+        var buffer: [1024]u8 = undefined;
+        const path = std.fs.selfExeDirPath(buffer[0..]) catch ".";
+        std.os.chdir(path) catch {};
+    }
+
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    try glfw.init();
+    defer glfw.terminate();
+
+    glfw.windowHintTyped(.client_api, .no_api);
+    const glfw_window = try glfw.Window.create(800, 600, window_name, null);
+    defer glfw_window.destroy();
+    glfw_window.setSizeLimits(400, 400, -1, -1);
+
+    zgui.init(allocator);
+    defer zgui.deinit();
+
+    const window = glfw.getWin32Window(glfw_window) orelse return error.FailedToGetWin32Window;
+    var gctx = zd3d12.GraphicsContext.init(allocator, window);
+    defer gctx.deinit(allocator);
+
+    const scale_factor = scale_factor: {
+        const scale = glfw_window.getContentScale();
+        break :scale_factor @max(scale[0], scale[1]);
+    };
+    _ = zgui.io.addFontFromFile(
+        content_dir ++ "Roboto-Medium.ttf",
+        std.math.floor(16.0 * scale_factor),
+    );
+
+    zgui.getStyle().scaleAllSizes(scale_factor);
+
+    {
+        const cbv_srv = gctx.cbv_srv_uav_gpu_heaps[0];
+        zgui.backend.init(
+            glfw_window,
+            gctx.device,
+            zd3d12.GraphicsContext.max_num_buffered_frames,
+            @intFromEnum(dxgi.FORMAT.R8G8B8A8_UNORM),
+            cbv_srv.heap.?,
+            @bitCast(cbv_srv.base.cpu_handle),
+            @bitCast(cbv_srv.base.gpu_handle),
+        );
+    }
+    defer zgui.backend.deinit();
+
+    var framebuffer_size = glfw_window.getFramebufferSize();
+
+    while (!glfw_window.shouldClose() and glfw_window.getKey(.escape) != .press) {
+        glfw.pollEvents();
+
+        if (glfw_window.getAttribute(.iconified)) {
+            // Window is minimized
+            const ns_in_ms: u64 = 1_000_000;
+            std.time.sleep(10 * ns_in_ms);
+            continue;
+        }
+
+        {
+            const next_framebuffer_size = glfw_window.getFramebufferSize();
+            if (!std.meta.eql(framebuffer_size, next_framebuffer_size)) {
+                gctx.resize(@intCast(next_framebuffer_size[0]), @intCast(next_framebuffer_size[1]));
+            }
+            framebuffer_size = next_framebuffer_size;
+        }
+
+        {
+            gctx.beginFrame();
+            defer gctx.endFrame();
+
+            const back_buffer = gctx.getBackBuffer();
+            gctx.addTransitionBarrier(back_buffer.resource_handle, .{ .RENDER_TARGET = true });
+            gctx.flushResourceBarriers();
+
+            gctx.cmdlist.OMSetRenderTargets(
+                1,
+                &[_]d3d12.CPU_DESCRIPTOR_HANDLE{back_buffer.descriptor_handle},
+                w32.TRUE,
+                null,
+            );
+            gctx.cmdlist.ClearRenderTargetView(
+                back_buffer.descriptor_handle,
+                &.{ 0.0, 0.0, 0.0, 1.0 },
+                0,
+                null,
+            );
+
+            zgui.backend.newFrame(@intCast(framebuffer_size[0]), @intCast(framebuffer_size[1]));
+
+            // Set the starting window position and size to custom values
+            zgui.setNextWindowPos(.{ .x = 20.0, .y = 20.0, .cond = .first_use_ever });
+            zgui.setNextWindowSize(.{ .w = -1.0, .h = -1.0, .cond = .first_use_ever });
+
+            if (zgui.begin("My window", .{})) {
+                if (zgui.button("Press me!", .{ .w = 200.0 })) {
+                    std.debug.print("Button pressed\n", .{});
+                }
+            }
+            zgui.end();
+
+            zgui.backend.draw(gctx.cmdlist);
+
+            gctx.addTransitionBarrier(back_buffer.resource_handle, d3d12.RESOURCE_STATES.PRESENT);
+            gctx.flushResourceBarriers();
+        }
+    }
+
+    gctx.finishGpuCommands();
+}


### PR DESCRIPTION
Looking for feedback on how to improve this call:
https://github.com/zig-gamedev/zig-gamedev/pull/519/files#diff-5d56ea36cb7e424a98b9756f43f8ed65fac2bbe159384ccecc0df12dc3c5d985R63

I didn't want to add [`zwin32.d3d12.CPU_DESCRIPTOR_HANDLE`](https://github.com/zig-gamedev/zig-gamedev/blob/193a1d278f2b4970745c171056c6480bca64bbf5/libs/zwin32/src/d3d12.zig#L64-L66) as a dep in zgui, so I ended up using a `@bitCast`.

Ditto for [`zwin32.dxgi.FORMAT`](https://github.com/zig-gamedev/zig-gamedev/blob/193a1d278f2b4970745c171056c6480bca64bbf5/libs/zwin32/src/dxgi.zig#L23).

The alternative is just to add some build conditions to only pull in zwin32 when using glfw_dx12 backend