### PR TITLE
audited and fixed zgui flags

### DIFF
--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -737,7 +737,10 @@ pub const HoveredFlags = packed struct(c_int) {
     allow_when_overlapped: bool = false,
     allow_when_disabled: bool = false,
     no_nav_override: bool = false,
-    _padding: u21 = 0,
+    delay_normal: bool = false,
+    delay_short: bool = false,
+    no_shared_delay: bool = false,
+    _padding: u18 = 0,
 
     pub const rect_only = HoveredFlags{
         .allow_when_blocked_by_popup = true,
@@ -2504,6 +2507,7 @@ extern fn zguiInputScalarN(
 //
 //--------------------------------------------------------------------------------------------------
 pub const ColorEditFlags = packed struct(c_int) {
+    _reserved0: bool = false,
     no_alpha: bool = false,
     no_picker: bool = false,
     no_options: bool = false,
@@ -2515,11 +2519,11 @@ pub const ColorEditFlags = packed struct(c_int) {
     no_drag_drop: bool = false,
     no_border: bool = false,
 
-    _reserved0: bool = false,
     _reserved1: bool = false,
     _reserved2: bool = false,
     _reserved3: bool = false,
     _reserved4: bool = false,
+    _reserved5: bool = false,
 
     alpha_bar: bool = false,
     alpha_preview: bool = false,
@@ -2535,7 +2539,7 @@ pub const ColorEditFlags = packed struct(c_int) {
     input_rgb: bool = false,
     input_hsv: bool = false,
 
-    _padding: u4 = 0,
+    _padding: u3 = 0,
 
     pub const default_options = ColorEditFlags{
         .uint8 = true,
@@ -3237,14 +3241,17 @@ pub const PopupFlags = packed struct(c_int) {
     mouse_button_left: bool = false,
     mouse_button_right: bool = false,
     mouse_button_middle: bool = false,
-    mouse_button_mask_: bool = false,
-    mouse_button_default_: bool = false,
+
+    _reserved0: bool = false,
+    _reserved1: bool = false,
+
     no_open_over_existing_popup: bool = false,
     no_open_over_items: bool = false,
     any_popup_id: bool = false,
     any_popup_level: bool = false,
-    any_popup: bool = false,
-    _padding: u22 = 0,
+    _padding: u23 = 0,
+
+    pub const any_popup = PopupFlags{ .any_popup_id = true, .any_popup_level = true };
 };
 pub fn beginPopupModal(name: [:0]const u8, args: Begin) bool {
     return zguiBeginPopupModal(name, args.popen, args.flags);
@@ -3280,12 +3287,6 @@ pub const TabBarFlags = packed struct(c_int) {
     fitting_policy_resize_down: bool = false,
     fitting_policy_scroll: bool = false,
     _padding: u24 = 0,
-
-    pub const fitting_policy_mask = TabBarFlags{
-        .fitting_policy_resize_down = true,
-        .fitting_policy_scroll = true,
-    };
-    pub const fitting_policy_default = TabBarFlags{ .fitting_policy_resize_down = true };
 };
 pub const TabItemFlags = packed struct(c_int) {
     unsaved_document: bool = false,

--- a/samples/gui_test_wgpu/src/gui_test_wgpu.zig
+++ b/samples/gui_test_wgpu/src/gui_test_wgpu.zig
@@ -416,12 +416,13 @@ fn update(demo: *DemoState) !void {
         if (zgui.collapsingHeader("Widgets: Color Editor/Picker", .{})) {
             const static = struct {
                 var col3: [3]f32 = .{ 0, 0, 0 };
-                var col4: [4]f32 = .{ 0, 0, 0, 0 };
+                var col4: [4]f32 = .{ 0, 1, 0, 0 };
                 var col3p: [3]f32 = .{ 0, 0, 0 };
                 var col4p: [4]f32 = .{ 0, 0, 0, 0 };
             };
             _ = zgui.colorEdit3("Color edit 3", .{ .col = &static.col3 });
             _ = zgui.colorEdit4("Color edit 4", .{ .col = &static.col4 });
+            _ = zgui.colorEdit4("Color edit 4 float", .{ .col = &static.col4, .flags = .{ .float = true } });
             _ = zgui.colorPicker3("Color picker 3", .{ .col = &static.col3p });
             _ = zgui.colorPicker4("Color picker 4", .{ .col = &static.col4p });
             _ = zgui.colorButton("color_button_id", .{ .col = .{ 0, 1, 0, 1 } });


### PR DESCRIPTION
This PR fixes the following misalignments:

1. The definition of [`ImGuiColorEditFlags_`](https://github.com/zig-gamedev/zig-gamedev/blob/a199efd5de1e861b60c92a7e98ac2fcb8f66bfde/libs/zgui/libs/imgui/imgui.h#L1633) skips the 0th flag.
2. Removed 2 [`ImGuiTabBarFlags_`](https://github.com/zig-gamedev/zig-gamedev/blob/a199efd5de1e861b60c92a7e98ac2fcb8f66bfde/libs/zgui/libs/imgui/imgui.h#L1105-L1106) internal consts
3. Added 3 missing [`ImGuiHoveredFlags_`](https://github.com/zig-gamedev/zig-gamedev/blob/a199efd5de1e861b60c92a7e98ac2fcb8f66bfde/libs/zgui/libs/imgui/imgui.h#L1289-L1291) fields
4. Removed 2 [`ImGuiPopupFlags_`](https://github.com/zig-gamedev/zig-gamedev/blob/a199efd5de1e861b60c92a7e98ac2fcb8f66bfde/libs/zgui/libs/imgui/imgui.h#L1059-L1060) internal consts
5. Fixed [`ImGuiPopupFlags_AnyPopup`](https://github.com/zig-gamedev/zig-gamedev/blob/a199efd5de1e861b60c92a7e98ac2fcb8f66bfde/libs/zgui/libs/imgui/imgui.h#L1065) to be a const instead of a field

A trick to check the zig packed struct is correct is to ensure the last field bit shift + padding + 1 equals the size of packed structed. For example, `ImGuiWindowFlags_UnsavedDocument` has a bit shift of 20 and `WindowFlags._padding` is 11. `20 + 11 + 1 == 32`, which is the size of `c_int`.