### PR TITLE
Fix zflecs build.zig, no artifact for flecs

### DIFF
--- a/libs/zflecs/README.md
+++ b/libs/zflecs/README.md
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
 
     const zflecs = b.dependency("zflecs", .{});
     exe.root_module.addImport("zflecs", zflecs.module("root"));
-    exe.linkLibrary(zbullet.artifact("flecs"));
+    exe.linkLibrary(zflecs.artifact("flecs"));
 }
 ```
 

--- a/libs/zflecs/build.zig
+++ b/libs/zflecs/build.zig
@@ -9,7 +9,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const flecs = b.addStaticLibrary(.{
-        .name = "zflecs",
+        .name = "flecs",
         .target = target,
         .optimize = optimize,
     });
@@ -24,6 +24,7 @@ pub fn build(b: *std.Build) void {
             if (@import("builtin").mode == .Debug) "-DFLECS_SANITIZE" else "",
         },
     });
+    b.installArtifact(flecs);
 
     if (target.result.os.tag == .windows) {
         flecs.linkSystemLibrary("ws2_32");


### PR DESCRIPTION
I couldn't get this build to work in blockens without these changes I think it needed an install artifacts and a different name than the package?

I modeled this after the imgui build.zig

My zig version: 0.12.0-dev.3428+d8bb139da

I also made this change for main because I think this is a problem in main too maybe?