### PR TITLE
[zgui] Fixed buffer type for inputText* to include null sentinel.

### DIFF
--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -2333,7 +2333,7 @@ pub const InputTextCallbackData = extern struct {
 pub const InputTextCallback = *const fn (data: *InputTextCallbackData) i32;
 //--------------------------------------------------------------------------------------------------
 pub fn inputText(label: [:0]const u8, args: struct {
-    buf: []u8,
+    buf: [:0]u8,
     flags: InputTextFlags = .{},
     callback: ?InputTextCallback = null,
     user_data: ?*anyopaque = null,
@@ -2357,7 +2357,7 @@ extern fn zguiInputText(
 ) bool;
 //--------------------------------------------------------------------------------------------------
 pub fn inputTextMultiline(label: [:0]const u8, args: struct {
-    buf: []u8,
+    buf: [:0]u8,
     w: f32 = 0.0,
     h: f32 = 0.0,
     flags: InputTextFlags = .{},
@@ -2388,7 +2388,7 @@ extern fn zguiInputTextMultiline(
 //--------------------------------------------------------------------------------------------------
 pub fn inputTextWithHint(label: [:0]const u8, args: struct {
     hint: [:0]const u8,
-    buf: []u8,
+    buf: [:0]u8,
     flags: InputTextFlags = .{},
     callback: ?InputTextCallback = null,
     user_data: ?*anyopaque = null,


### PR DESCRIPTION
The slice length is for maximum text length, whereas the sentinel denotes the current text length.

Added output of current text length, which would have errored before this change since the buffers didn't include a sentinel in their type.

See https://github.com/zig-gamedev/zig-gamedev/issues/352#issuecomment-2038175998