### PR TITLE
zgui: Expose DockBuilder API - partial coverage implemented and working

### DIFF
--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -881,7 +881,23 @@ pub const DockNodeFlags = packed struct(c_int) {
     no_resize: bool = false,
     auto_hide_tab_bar: bool = false,
     no_undocking: bool = false,
-    _padding: u24 = 0,
+    _padding_0: u2 = 0,
+
+    // Extended enum entries from imgui_internal (unstable, subject to change, use at own risk)
+    dock_space: bool = false,
+    central_node: bool = false,
+    no_tab_bar: bool = false,
+    hidden_tab_bar: bool = false,
+    no_window_menu_button: bool = false,
+    no_close_button: bool = false,
+    no_resize_x: bool = false,
+    no_resize_y: bool = false,
+    docked_windows_in_focus_route: bool = false,
+    no_docking_split_other: bool = false,
+    no_docking_over_me: bool = false,
+    no_docking_over_other: bool = false,
+    no_docking_over_empty: bool = false,
+    _padding_1: u9 = 0,
 };
 extern fn zguiDockSpace(str_id: [*:0]const u8, size: *const [2]f32, flags: DockNodeFlags) Ident;
 

--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -892,6 +892,37 @@ extern fn zguiDockSpaceOverViewport(viewport: Viewport, flags: DockNodeFlags) Id
 pub const DockSpaceOverViewport = zguiDockSpaceOverViewport;
 
 //--------------------------------------------------------------------------------------------------
+//
+// DockBuilder (Unstable internal imgui API, subject to change, use at own risk)
+//
+//--------------------------------------------------------------------------------------------------
+pub fn dockBuilderDockWindow(window_name: [:0]const u8, node_id: Ident) void {
+    zguiDockBuilderDockWindow(window_name.ptr, node_id);
+}
+pub const dockBuilderAddNode = zguiDockBuilderAddNode;
+pub const dockBuilderRemoveNode = zguiDockBuilderRemoveNode;
+pub fn dockBuilderSetNodePos(node_id: Ident, pos: [2]f32) void {
+    zguiDockBuilderSetNodePos(node_id, &pos);
+}
+pub fn dockBuilderSetNodeSize(node_id: Ident, size: [2]f32) void {
+    zguiDockBuilderSetNodeSize(node_id, &size);
+}
+pub const dockBuilderSplitNode = zguiDockBuilderSplitNode;
+pub const dockBuilderFinish = zguiDockBuilderFinish;
+
+extern fn zguiDockBuilderDockWindow(window_name: [*:0]const u8, node_id: Ident) void;
+extern fn zguiDockBuilderAddNode(node_id: Ident, flags: DockNodeFlags) Ident;
+extern fn zguiDockBuilderRemoveNode(node_id: Ident) void;
+extern fn zguiDockBuilderSetNodePos(node_id: Ident, pos: *const [2]f32) void;
+extern fn zguiDockBuilderSetNodeSize(node_id: Ident, size: *const [2]f32) void;
+extern fn zguiDockBuilderSplitNode(
+    node_id: Ident,
+    split_dir: Direction,
+    size_ratio_for_node_at_dir: f32,
+    out_id_at_dir: ?*Ident,
+    out_id_at_opposite_dir: ?*Ident
+) Ident;
+extern fn zguiDockBuilderFinish(node_id: Ident) void;
 
 //--------------------------------------------------------------------------------------------------
 //

--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -915,13 +915,7 @@ extern fn zguiDockBuilderAddNode(node_id: Ident, flags: DockNodeFlags) Ident;
 extern fn zguiDockBuilderRemoveNode(node_id: Ident) void;
 extern fn zguiDockBuilderSetNodePos(node_id: Ident, pos: *const [2]f32) void;
 extern fn zguiDockBuilderSetNodeSize(node_id: Ident, size: *const [2]f32) void;
-extern fn zguiDockBuilderSplitNode(
-    node_id: Ident,
-    split_dir: Direction,
-    size_ratio_for_node_at_dir: f32,
-    out_id_at_dir: ?*Ident,
-    out_id_at_opposite_dir: ?*Ident
-) Ident;
+extern fn zguiDockBuilderSplitNode(node_id: Ident, split_dir: Direction, size_ratio_for_node_at_dir: f32, out_id_at_dir: ?*Ident, out_id_at_opposite_dir: ?*Ident) Ident;
 extern fn zguiDockBuilderFinish(node_id: Ident) void;
 
 //--------------------------------------------------------------------------------------------------

--- a/libs/zgui/src/zgui.cpp
+++ b/libs/zgui/src/zgui.cpp
@@ -12,6 +12,8 @@
 #include "imgui_te_exporters.h"
 #endif
 
+#include "imgui_internal.h"
+
 #ifndef ZGUI_API
 #define ZGUI_API
 #endif
@@ -2227,6 +2229,52 @@ ZGUI_API ImGuiID zguiDockSpace(const char* str_id, float size[2], ImGuiDockNodeF
 
 ZGUI_API ImGuiID zguiDockSpaceOverViewport(const ImGuiViewport* viewport, ImGuiDockNodeFlags dockspace_flags) {
     return ImGui::DockSpaceOverViewport(viewport, dockspace_flags);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+//
+// DockBuilder (Unstable internal imgui API, subject to change, use at own risk)
+//
+//--------------------------------------------------------------------------------------------------
+ZGUI_API void zguiDockBuilderDockWindow(const char* window_name, ImGuiID node_id) {
+    ImGui::DockBuilderDockWindow(window_name, node_id);
+}
+
+ZGUI_API ImGuiID zguiDockBuilderAddNode(ImGuiID node_id, ImGuiDockNodeFlags flags) {
+    return ImGui::DockBuilderAddNode(node_id, flags);
+}
+
+ZGUI_API void zguiDockBuilderRemoveNode(ImGuiID node_id) {
+    ImGui::DockBuilderRemoveNode(node_id);
+}
+
+ZGUI_API void zguiDockBuilderSetNodePos(ImGuiID node_id, float pos[2]) {
+    ImGui::DockBuilderSetNodePos(node_id, {pos[0], pos[1]});
+}
+
+ZGUI_API void zguiDockBuilderSetNodeSize(ImGuiID node_id, float size[2]) {
+    ImGui::DockBuilderSetNodeSize(node_id, {size[0], size[1]});
+}
+
+ZGUI_API ImGuiID zguiDockBuilderSplitNode(
+    ImGuiID node_id,
+    ImGuiDir split_dir,
+    float size_ratio_for_node_at_dir,
+    ImGuiID* out_id_at_dir,
+    ImGuiID* out_id_at_opposite_dir
+) {
+    return ImGui::DockBuilderSplitNode(
+        node_id,
+        split_dir,
+        size_ratio_for_node_at_dir,
+        out_id_at_dir,
+        out_id_at_opposite_dir
+    );
+}
+
+ZGUI_API void zguiDockBuilderFinish(ImGuiID node_id) {
+    ImGui::DockBuilderFinish(node_id);
 }
 
 


### PR DESCRIPTION
Imgui's internal DockBuilder API has more functions than just these, which are not yet exposed, but these ones I've exposed are sufficient to use the API for basic examples (and for my purposes).

Let me know if there's anything that should be changed. I whipped this up and lightly tested it with my own code, as usual, but if more is needed for this to be merged, I can do more.