### PR TITLE
[zgui] fixed off by one for text input due to sentinel

### DIFF
--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -2389,7 +2389,7 @@ pub fn inputText(label: [:0]const u8, args: struct {
     return zguiInputText(
         label,
         args.buf.ptr,
-        args.buf.len,
+        args.buf.len + 1, // + 1 for sentinel
         args.flags,
         if (args.callback) |cb| cb else null,
         args.user_data,
@@ -2415,7 +2415,7 @@ pub fn inputTextMultiline(label: [:0]const u8, args: struct {
     return zguiInputTextMultiline(
         label,
         args.buf.ptr,
-        args.buf.len,
+        args.buf.len + 1, // + 1 for sentinel
         args.w,
         args.h,
         args.flags,
@@ -2445,7 +2445,7 @@ pub fn inputTextWithHint(label: [:0]const u8, args: struct {
         label,
         args.hint,
         args.buf.ptr,
-        args.buf.len,
+        args.buf.len + 1, // + 1 for sentinel
         args.flags,
         if (args.callback) |cb| cb else null,
         args.user_data,

--- a/samples/gui_test_wgpu/src/gui_test_wgpu.zig
+++ b/samples/gui_test_wgpu/src/gui_test_wgpu.zig
@@ -135,9 +135,9 @@ fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
         .font_normal = font_normal,
         .font_large = font_large,
         .draw_list = draw_list,
-        .alloced_input_text_buf = try allocator.allocSentinel(u8, 128, 0),
-        .alloced_input_text_multiline_buf = try allocator.allocSentinel(u8, 128, 0),
-        .alloced_input_text_with_hint_buf = try allocator.allocSentinel(u8, 128, 0),
+        .alloced_input_text_buf = try allocator.allocSentinel(u8, 4, 0),
+        .alloced_input_text_multiline_buf = try allocator.allocSentinel(u8, 4, 0),
+        .alloced_input_text_with_hint_buf = try allocator.allocSentinel(u8, 4, 0),
     };
     demo.alloced_input_text_buf[0] = 0;
     demo.alloced_input_text_multiline_buf[0] = 0;
@@ -474,9 +474,9 @@ fn update(demo: *DemoState) !void {
 
         if (zgui.collapsingHeader("Widgets: Input with Keyboard", .{})) {
             const static = struct {
-                var input_text_buf = [_:0]u8{0} ** 128;
-                var input_text_multiline_buf = [_:0]u8{0} ** 128;
-                var input_text_with_hint_buf = [_:0]u8{0} ** 128;
+                var input_text_buf = [_:0]u8{0} ** 4;
+                var input_text_multiline_buf = [_:0]u8{0} ** 4;
+                var input_text_with_hint_buf = [_:0]u8{0} ** 4;
                 var v1: f32 = 0;
                 var v2: [2]f32 = .{ 0, 0 };
                 var v3: [3]f32 = .{ 0, 0, 0 };


### PR DESCRIPTION
Fixed a bug with #541, where the given slice length didn't account for sentinel and would segfault.

Segfault case:
```zig
var buffer: [4:0]u8 = [_:0]u8{ 'w', 'a', 's', 'd' };
zgui.inputText("##", .{.buf = buffer[0..]});
```

`buffer` is actually 5 bytes `'w', 'a', 's', 'd', 0`, but `buffer[0..].len` returns 4. So before this fix, imgui would see the bytes `wasd`, and since it wasn't zero terminated, it would segfault.