### PR TITLE
Disabled the system sdk library path on windows+msvc since dxguid was…

### DIFF
--- a/libs/system-sdk/build.zig
+++ b/libs/system-sdk/build.zig
@@ -11,9 +11,11 @@ pub fn addLibraryPathsTo(compile_step: *std.Build.Step.Compile) void {
     switch (target.os.tag) {
         .windows => {
             if (target.cpu.arch.isX86()) {
-                compile_step.addLibraryPath(.{
-                    .path = system_sdk.path("windows/lib/x86_64-windows-gnu").getPath(b),
-                });
+                if (target.abi.isGnu() or target.abi.isMusl()) {
+                    compile_step.addLibraryPath(.{
+                        .path = system_sdk.path("windows/lib/x86_64-windows-gnu").getPath(b),
+                    });
+                }
             }
         },
         .macos => {


### PR DESCRIPTION
… missing symbols.

Yeah so on Tides with The-Forge, when I tried to build now, we were missing the symbol DXGI_DEBUG_ALL, which is supposed to be in dxguid.lib. However the version of dxguid.lib that is in the system sdk at:

> zig-gamedev\libs\system-sdk\windows\lib\x86_64-windows-gnu\dxguid.lib

Is significantly smaller than the one that comes with the windows sdk and doesn't include this specific symbol, and potentially others too?

I'm not sure if this is the best solution but by simply not having this dxguid.lib on the library path, I guess another one is found that does have the symbol. (I have a few of them on my computer)