### PR TITLE
BREAKING: changed zd3d12 create*ShaderPipeline and MipmapGenerator to require shader bytecode

### DIFF
--- a/libs/zwin32/src/d3d12.zig
+++ b/libs/zwin32/src/d3d12.zig
@@ -805,6 +805,13 @@ pub const SHADER_BYTECODE = extern struct {
     pub inline fn initZero() SHADER_BYTECODE {
         return std.mem.zeroes(@This());
     }
+
+    pub inline fn init(bytecode: []const u8) SHADER_BYTECODE {
+        return .{
+            .pShaderBytecode = bytecode.ptr,
+            .BytecodeLength = bytecode.len,
+        };
+    }
 };
 
 pub const SO_DECLARATION_ENTRY = extern struct {

--- a/samples/audio_experiments/src/audio_experiments.zig
+++ b/samples/audio_experiments/src/audio_experiments.zig
@@ -212,13 +212,10 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         pso_desc.DSVFormat = .D32_FLOAT;
         pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .LINE;
+        pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/lines.vs.cso", null));
+        pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/lines.ps.cso", null));
 
-        break :blk gctx.createGraphicsShaderPipeline(
-            arena_allocator,
-            &pso_desc,
-            content_dir ++ "shaders/lines.vs.cso",
-            content_dir ++ "shaders/lines.ps.cso",
-        );
+        break :blk gctx.createGraphicsShaderPipeline(&pso_desc);
     };
 
     // Create depth texture resource.

--- a/samples/audio_playback_test/src/audio_playback_test.zig
+++ b/samples/audio_playback_test/src/audio_playback_test.zig
@@ -270,13 +270,10 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         pso_desc.PrimitiveTopologyType = .LINE;
         pso_desc.DepthStencilState.DepthEnable = w32.FALSE;
         pso_desc.RasterizerState.AntialiasedLineEnable = w32.TRUE;
+        pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/lines.vs.cso", null));
+        pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/lines.ps.cso", null));
 
-        break :blk gctx.createGraphicsShaderPipeline(
-            arena_allocator,
-            &pso_desc,
-            content_dir ++ "shaders/lines.vs.cso",
-            content_dir ++ "shaders/lines.ps.cso",
-        );
+        break :blk gctx.createGraphicsShaderPipeline(&pso_desc);
     };
 
     const image_pso = blk: {
@@ -286,13 +283,10 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.DepthStencilState.DepthEnable = w32.FALSE;
+        pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/image.vs.cso", null));
+        pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/image.ps.cso", null));
 
-        break :blk gctx.createGraphicsShaderPipeline(
-            arena_allocator,
-            &pso_desc,
-            content_dir ++ "shaders/image.vs.cso",
-            content_dir ++ "shaders/image.ps.cso",
-        );
+        break :blk gctx.createGraphicsShaderPipeline(&pso_desc);
     };
 
     const lines_buffer = gctx.createCommittedResource(

--- a/samples/common/src/GuiRenderer.zig
+++ b/samples/common/src/GuiRenderer.zig
@@ -8,7 +8,8 @@ const d3d12 = zwin32.d3d12;
 const hrPanic = zwin32.hrPanic;
 const hrPanicOnFail = zwin32.hrPanicOnFail;
 const zd3d12 = @import("zd3d12");
-const c = @import("common.zig").c;
+const common = @import("common.zig");
+const c = common.c;
 
 font: zd3d12.ResourceHandle,
 font_srv: d3d12.CPU_DESCRIPTOR_HANDLE,
@@ -86,12 +87,9 @@ pub fn init(
         pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.SampleDesc = .{ .Count = num_msaa_samples, .Quality = 0 };
-        break :blk gctx.createGraphicsShaderPipeline(
-            arena,
-            &pso_desc,
-            content_dir ++ "shaders/imgui.vs.cso",
-            content_dir ++ "shaders/imgui.ps.cso",
-        );
+        pso_desc.VS = d3d12.SHADER_BYTECODE.init(common.readContentDirFileAlloc(arena, content_dir, "shaders/imgui.vs.cso", null) catch unreachable);
+        pso_desc.PS = d3d12.SHADER_BYTECODE.init(common.readContentDirFileAlloc(arena, content_dir, "shaders/imgui.ps.cso", null) catch unreachable);
+        break :blk gctx.createGraphicsShaderPipeline(&pso_desc);
     };
     return GuiRenderer{
         .font = font,

--- a/samples/common/src/common.zig
+++ b/samples/common/src/common.zig
@@ -464,6 +464,16 @@ pub fn drawText(
     );
 }
 
+pub fn readContentDirFileAlloc(arena_allocator: std.mem.Allocator, content_dir: []const u8, relpath: []const u8, max_bytes: ?usize) ![]u8 {
+    const self_exe_dir_path = try std.fs.selfExeDirPathAlloc(arena_allocator);
+
+    const content_dir_path = try std.fs.path.join(arena_allocator, &.{ self_exe_dir_path, content_dir });
+
+    const self_exe_dir = try std.fs.openDirAbsolute(content_dir_path, .{});
+
+    return self_exe_dir.readFileAlloc(arena_allocator, relpath, max_bytes orelse 256 * 1024);
+}
+
 pub fn init() void {
     _ = w32.CoInitializeEx(null, w32.COINIT_APARTMENTTHREADED | w32.COINIT_DISABLE_OLE1DDE);
     _ = w32.SetProcessDPIAware();

--- a/samples/directml_convolution_test/src/directml_convolution_test.zig
+++ b/samples/directml_convolution_test/src/directml_convolution_test.zig
@@ -96,30 +96,21 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.DepthStencilState.DepthEnable = w32.FALSE;
+        pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/draw_texture.vs.cso", null));
+        pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/draw_texture.ps.cso", null));
 
-        break :blk gctx.createGraphicsShaderPipeline(
-            arena_allocator,
-            &pso_desc,
-            content_dir ++ "shaders/draw_texture.vs.cso",
-            content_dir ++ "shaders/draw_texture.ps.cso",
-        );
+        break :blk gctx.createGraphicsShaderPipeline(&pso_desc);
     };
 
     const texture_to_buffer_pso = blk: {
         var desc = d3d12.COMPUTE_PIPELINE_STATE_DESC.initDefault();
-        break :blk gctx.createComputeShaderPipeline(
-            arena_allocator,
-            &desc,
-            content_dir ++ "shaders/texture_to_buffer.cs.cso",
-        );
+        desc.CS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/texture_to_buffer.cs.cso", null));
+        break :blk gctx.createComputeShaderPipeline(&desc);
     };
     const buffer_to_texture_pso = blk: {
         var desc = d3d12.COMPUTE_PIPELINE_STATE_DESC.initDefault();
-        break :blk gctx.createComputeShaderPipeline(
-            arena_allocator,
-            &desc,
-            content_dir ++ "shaders/buffer_to_texture.cs.cso",
-        );
+        desc.CS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/buffer_to_texture.cs.cso", null));
+        break :blk gctx.createComputeShaderPipeline(&desc);
     };
 
     var dml_device: *dml.IDevice1 = undefined;

--- a/samples/mesh_shader_test/src/mesh_shader_test.zig
+++ b/samples/mesh_shader_test/src/mesh_shader_test.zig
@@ -280,14 +280,10 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.SampleDesc = .{ .Count = 1, .Quality = 0 };
+        pso_desc.MS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/mesh_shader.ms.cso", null));
+        pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/mesh_shader.ps.cso", null));
 
-        break :blk gctx.createMeshShaderPipeline(
-            arena_allocator,
-            &pso_desc,
-            null,
-            content_dir ++ "shaders/mesh_shader.ms.cso",
-            content_dir ++ "shaders/mesh_shader.ps.cso",
-        );
+        break :blk gctx.createMeshShaderPipeline(&pso_desc);
     };
 
     const vertex_shader_pso = blk: {
@@ -298,13 +294,10 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.SampleDesc = .{ .Count = 1, .Quality = 0 };
+        pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/vertex_shader.vs.cso", null));
+        pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/vertex_shader.ps.cso", null));
 
-        break :blk gctx.createGraphicsShaderPipeline(
-            arena_allocator,
-            &pso_desc,
-            content_dir ++ "shaders/vertex_shader.vs.cso",
-            content_dir ++ "shaders/vertex_shader.ps.cso",
-        );
+        break :blk gctx.createGraphicsShaderPipeline(&pso_desc);
     };
 
     const vertex_shader_fixed_pso = blk: {
@@ -324,13 +317,10 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.DSVFormat = .D32_FLOAT;
         pso_desc.SampleDesc = .{ .Count = 1, .Quality = 0 };
+        pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/vertex_shader_fixed.vs.cso", null));
+        pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/vertex_shader_fixed.ps.cso", null));
 
-        break :blk gctx.createGraphicsShaderPipeline(
-            arena_allocator,
-            &pso_desc,
-            content_dir ++ "shaders/vertex_shader_fixed.vs.cso",
-            content_dir ++ "shaders/vertex_shader_fixed.ps.cso",
-        );
+        break :blk gctx.createGraphicsShaderPipeline(&pso_desc);
     };
 
     zmesh.init(arena_allocator);

--- a/samples/minimal_glfw_d3d12/build.zig
+++ b/samples/minimal_glfw_d3d12/build.zig
@@ -25,14 +25,21 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const zwin32 = b.dependency("zwin32", .{
         .target = options.target,
     });
-    exe.root_module.addImport("zwin32", zwin32.module("root"));
+    const zwin32_module = zwin32.module("root");
+    exe.root_module.addImport("zwin32", zwin32_module);
 
     const zd3d12 = b.dependency("zd3d12", .{
         .target = options.target,
         .debug_layer = options.zd3d12_enable_debug_layer,
         .gbv = options.zd3d12_enable_gbv,
     });
-    exe.root_module.addImport("zd3d12", zd3d12.module("root"));
+    const zd3d12_module = zd3d12.module("root");
+    exe.root_module.addImport("zd3d12", zd3d12_module);
+
+    @import("../common/build.zig").link(exe, .{
+        .zwin32 = zwin32_module,
+        .zd3d12 = zd3d12_module,
+    });
 
     if (builtin.os.tag == .windows or builtin.os.tag == .linux) {
         const dxc_step = buildShaders(b);

--- a/samples/minimal_glfw_d3d12/src/minimal_glfw_d3d12.zig
+++ b/samples/minimal_glfw_d3d12/src/minimal_glfw_d3d12.zig
@@ -4,6 +4,7 @@ const zwin32 = @import("zwin32");
 const zd3d12 = @import("zd3d12");
 const w32 = zwin32.w32;
 const d3d12 = zwin32.d3d12;
+const common = @import("common");
 
 pub export const D3D12SDKVersion: u32 = 610;
 pub export const D3D12SDKPath: [*:0]const u8 = ".\\d3d12\\";
@@ -39,13 +40,10 @@ pub fn main() !void {
         pso_desc.NumRenderTargets = 1;
         pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
+        pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "minimal_glfw_d3d12.vs.cso", null));
+        pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "minimal_glfw_d3d12.ps.cso", null));
 
-        break :pipeline gctx.createGraphicsShaderPipeline(
-            arena_allocator,
-            &pso_desc,
-            content_dir ++ "minimal_glfw_d3d12.vs.cso",
-            content_dir ++ "minimal_glfw_d3d12.ps.cso",
-        );
+        break :pipeline gctx.createGraphicsShaderPipeline(&pso_desc);
     };
 
     var frac: f32 = 0.0;

--- a/samples/rasterization/src/rasterization.zig
+++ b/samples/rasterization/src/rasterization.zig
@@ -119,13 +119,9 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         pso_desc.DSVFormat = .D32_FLOAT;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.RasterizerState.CullMode = .NONE;
+        pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/draw_mesh.vs.cso", null));
 
-        break :blk gctx.createGraphicsShaderPipeline(
-            arena_allocator,
-            &pso_desc,
-            content_dir ++ "shaders/draw_mesh.vs.cso",
-            null,
-        );
+        break :blk gctx.createGraphicsShaderPipeline(&pso_desc);
     };
 
     const record_pixels_pso = blk: {
@@ -146,13 +142,10 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         pso_desc.DepthStencilState.DepthWriteMask = .ZERO;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.RasterizerState.CullMode = .NONE;
+        pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/record_pixels.vs.cso", null));
+        pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/record_pixels.ps.cso", null));
 
-        break :blk gctx.createGraphicsShaderPipeline(
-            arena_allocator,
-            &pso_desc,
-            content_dir ++ "shaders/record_pixels.vs.cso",
-            content_dir ++ "shaders/record_pixels.ps.cso",
-        );
+        break :blk gctx.createGraphicsShaderPipeline(&pso_desc);
     };
 
     const draw_mesh_pso = blk: {
@@ -175,30 +168,23 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         pso_desc.DepthStencilState.DepthFunc = .LESS_EQUAL;
         pso_desc.DepthStencilState.DepthWriteMask = .ZERO;
         pso_desc.RasterizerState.AntialiasedLineEnable = w32.TRUE;
+        pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/draw_mesh.vs.cso", null));
+        pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/draw_mesh.ps.cso", null));
 
-        break :blk gctx.createGraphicsShaderPipeline(
-            arena_allocator,
-            &pso_desc,
-            content_dir ++ "shaders/draw_mesh.vs.cso",
-            content_dir ++ "shaders/draw_mesh.ps.cso",
-        );
+        break :blk gctx.createGraphicsShaderPipeline(&pso_desc);
     };
 
     const draw_pixels_pso = draw_pixels_pso: {
         var desc = d3d12.COMPUTE_PIPELINE_STATE_DESC.initDefault();
+        desc.CS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/draw_pixels.cs.cso", null));
         break :draw_pixels_pso gctx.createComputeShaderPipeline(
-            arena_allocator,
             &desc,
-            content_dir ++ "shaders/draw_pixels.cs.cso",
         );
     };
     const clear_pixels_pso = clear_pixels_pso: {
         var desc = d3d12.COMPUTE_PIPELINE_STATE_DESC.initDefault();
-        break :clear_pixels_pso gctx.createComputeShaderPipeline(
-            arena_allocator,
-            &desc,
-            content_dir ++ "shaders/clear_pixels.cs.cso",
-        );
+        desc.CS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/clear_pixels.cs.cso", null));
+        break :clear_pixels_pso gctx.createComputeShaderPipeline(&desc);
     };
 
     zmesh.init(arena_allocator);
@@ -363,7 +349,8 @@ fn init(allocator: std.mem.Allocator) !DemoState {
 
     // Generate mipmaps.
     {
-        var mipgen = zd3d12.MipmapGenerator.init(arena_allocator, &gctx, .R8G8B8A8_UNORM, content_dir);
+        const mipmapgen_bytecode = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/generate_mipmaps.cs.cso", null));
+        var mipgen = zd3d12.MipmapGenerator.init(&gctx, .R8G8B8A8_UNORM, mipmapgen_bytecode);
         defer mipgen.deinit(&gctx);
         for (mesh_textures) |texture| {
             mipgen.generateMipmaps(&gctx, texture);

--- a/samples/simple_raytracer/src/simple_raytracer.zig
+++ b/samples/simple_raytracer/src/simple_raytracer.zig
@@ -481,13 +481,10 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         pso_desc.DSVFormat = .D32_FLOAT;
         pso_desc.DepthStencilState.DepthFunc = .LESS_EQUAL;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
+        pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/rast_static_mesh.vs.cso"));
+        pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/rast_static_mesh.ps.cso"));
 
-        break :blk gctx.createGraphicsShaderPipeline(
-            arena_allocator,
-            &pso_desc,
-            content_dir ++ "shaders/rast_static_mesh.vs.cso",
-            content_dir ++ "shaders/rast_static_mesh.ps.cso",
-        );
+        break :blk gctx.createGraphicsShaderPipeline(&pso_desc);
     };
 
     const z_pre_pass_pso = blk: {
@@ -497,13 +494,10 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0x0;
         pso_desc.DSVFormat = .D32_FLOAT;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
+        pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/z_pre_pass.vs.cso"));
+        pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/z_pre_pass.ps.cso"));
 
-        break :blk gctx.createGraphicsShaderPipeline(
-            arena_allocator,
-            &pso_desc,
-            content_dir ++ "shaders/z_pre_pass.vs.cso",
-            content_dir ++ "shaders/z_pre_pass.ps.cso",
-        );
+        break :blk gctx.createGraphicsShaderPipeline(&pso_desc);
     };
 
     const gen_shadow_rays_pso = blk: {
@@ -515,13 +509,10 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         pso_desc.DepthStencilState.DepthWriteMask = .ZERO;
         pso_desc.DepthStencilState.DepthFunc = .LESS_EQUAL;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
+        pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/gen_shadow_rays.vs.cso"));
+        pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/gen_shadow_rays.ps.cso"));
 
-        break :blk gctx.createGraphicsShaderPipeline(
-            arena_allocator,
-            &pso_desc,
-            content_dir ++ "shaders/gen_shadow_rays.vs.cso",
-            content_dir ++ "shaders/gen_shadow_rays.ps.cso",
-        );
+        break :blk gctx.createGraphicsShaderPipeline(&pso_desc);
     };
 
     // Create 'trace shadow rays' RT state object.

--- a/samples/textured_quad/src/textured_quad.zig
+++ b/samples/textured_quad/src/textured_quad.zig
@@ -68,13 +68,10 @@ const DemoState = struct {
                 .pInputElementDescs = &input_layout_desc,
                 .NumElements = input_layout_desc.len,
             };
+            pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/textured_quad.vs.cso", null));
+            pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/textured_quad.ps.cso", null));
 
-            break :blk gctx.createGraphicsShaderPipeline(
-                arena_allocator,
-                &pso_desc,
-                content_dir ++ "shaders/textured_quad.vs.cso",
-                content_dir ++ "shaders/textured_quad.ps.cso",
-            );
+            break :blk gctx.createGraphicsShaderPipeline(&pso_desc);
         };
 
         const vertex_buffer = gctx.createCommittedResource(
@@ -93,7 +90,8 @@ const DemoState = struct {
             null,
         ) catch |err| hrPanic(err);
 
-        var mipgen = zd3d12.MipmapGenerator.init(arena_allocator, &gctx, .R8G8B8A8_UNORM, content_dir);
+        const mipmapgen_bytecode = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/generate_mipmaps.cs.cso", null));
+        var mipgen = zd3d12.MipmapGenerator.init(&gctx, .R8G8B8A8_UNORM, mipmapgen_bytecode);
 
         gctx.beginFrame();
 

--- a/samples/triangle/src/triangle.zig
+++ b/samples/triangle/src/triangle.zig
@@ -52,13 +52,10 @@ pub fn main() !void {
         pso_desc.NumRenderTargets = 1;
         pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
+        pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/triangle.vs.cso", null));
+        pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/triangle.ps.cso", null));
 
-        break :blk gctx.createGraphicsShaderPipeline(
-            arena_allocator,
-            &pso_desc,
-            content_dir ++ "shaders/triangle.vs.cso",
-            content_dir ++ "shaders/triangle.ps.cso",
-        );
+        break :blk gctx.createGraphicsShaderPipeline(&pso_desc);
     };
 
     const vertex_buffer = gctx.createCommittedResource(


### PR DESCRIPTION
Removes all `std.fs.openFileAbsolute` out of `zd3d12.zig`, but there still remain indirect file loading via `gctx.wic_factory.CreateDecoderFromFilename` and `dds_loading.zig`

Can be improved by extracting `csGenerateMipmaps` out of `samples/common/src/hlsl/common.hsls` and put it into zd3d12 with a shader compilation step template.

fixes #556