### PR TITLE
zphysics: ConvexHullShape: Some shape-exclusive methods exposed

### DIFF
--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
@@ -221,6 +221,11 @@ FN(toJph)(JPC_CompoundShapeSettings *in) {
     return reinterpret_cast<JPH::CompoundShapeSettings *>(in);
 }
 
+FN(toJph)(JPC_ConvexHullShape *in) { assert(in); return reinterpret_cast<JPH::ConvexHullShape *>(in); }
+FN(toJph)(const JPC_ConvexHullShape *in) { assert(in); return reinterpret_cast<const JPH::ConvexHullShape *>(in); }
+FN(toJpc)(JPH::ConvexHullShape *in) { assert(in); return reinterpret_cast<JPC_ConvexHullShape *>(in); }
+FN(toJpc)(const JPH::ConvexHullShape *in) { assert(in); return reinterpret_cast<const JPC_ConvexHullShape *>(in); }
+
 FN(toJph)(const JPC_ConstraintSettings *in) {
     ENSURE_TYPE(in, JPH::ConstraintSettings);
     return reinterpret_cast<const JPH::ConstraintSettings *>(in);
@@ -1837,6 +1842,43 @@ JPC_API void
 JPC_Shape_GetCenterOfMass(const JPC_Shape *in_shape, JPC_Real out_position[3])
 {
     storeRVec3(out_position, toJph(in_shape)->GetCenterOfMass());
+}
+//--------------------------------------------------------------------------------------------------
+//
+// JPC_ConvexHullShape
+//
+//--------------------------------------------------------------------------------------------------
+JPC_API uint32_t
+JPC_ConvexHullShape_GetNumPoints(const JPC_ConvexHullShape *in_shape)
+{
+    return toJph(in_shape)->GetNumPoints();
+}
+//--------------------------------------------------------------------------------------------------
+JPC_API void
+JPC_ConvexHullShape_GetPoint(const JPC_ConvexHullShape *in_shape, uint32_t in_point_index, float out_point[3])
+{
+    storeVec3(out_point, toJph(in_shape)->GetPoint(in_point_index));
+}
+//--------------------------------------------------------------------------------------------------
+JPC_API uint32_t
+JPC_ConvexHullShape_GetNumFaces(const JPC_ConvexHullShape *in_shape)
+{
+    return toJph(in_shape)->GetNumFaces();
+}
+//--------------------------------------------------------------------------------------------------
+JPC_API uint32_t
+JPC_ConvexHullShape_GetNumVerticesInFace(const JPC_ConvexHullShape *in_shape, uint32_t in_face_index)
+{
+    return toJph(in_shape)->GetNumVerticesInFace(in_face_index);
+}
+//--------------------------------------------------------------------------------------------------
+JPC_API uint32_t
+JPC_ConvexHullShape_GetFaceVertices(const JPC_ConvexHullShape *in_shape,
+                                    uint32_t in_face_index,
+                                    uint32_t in_max_vertices,
+                                    uint32_t *out_vertices)
+{
+    return toJph(in_shape)->GetFaceVertices(in_face_index, in_max_vertices, out_vertices);
 }
 //--------------------------------------------------------------------------------------------------
 //

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.h
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.h
@@ -303,7 +303,9 @@ typedef struct JPC_FixedConstraintSettings   JPC_FixedConstraintSettings;
 typedef struct JPC_PhysicsSystem JPC_PhysicsSystem;
 typedef struct JPC_SharedMutex   JPC_SharedMutex;
 
-typedef struct JPC_Shape            JPC_Shape;
+typedef struct JPC_Shape           JPC_Shape;
+typedef struct JPC_ConvexHullShape JPC_ConvexHullShape;
+
 typedef struct JPC_Constraint       JPC_Constraint;
 typedef struct JPC_PhysicsMaterial  JPC_PhysicsMaterial;
 typedef struct JPC_GroupFilter      JPC_GroupFilter;
@@ -1581,6 +1583,28 @@ JPC_Shape_SetUserData(JPC_Shape *in_shape, uint64_t in_user_data);
 
 JPC_API void
 JPC_Shape_GetCenterOfMass(const JPC_Shape *in_shape, JPC_Real out_position[3]);
+//--------------------------------------------------------------------------------------------------
+//
+// JPC_ConvexHullShape
+//
+//--------------------------------------------------------------------------------------------------
+JPC_API uint32_t
+JPC_ConvexHullShape_GetNumPoints(const JPC_ConvexHullShape *in_shape);
+
+JPC_API void
+JPC_ConvexHullShape_GetPoint(const JPC_ConvexHullShape *in_shape, uint32_t in_point_index, float out_point[3]);
+
+JPC_API uint32_t
+JPC_ConvexHullShape_GetNumFaces(const JPC_ConvexHullShape *in_shape);
+
+JPC_API uint32_t
+JPC_ConvexHullShape_GetNumVerticesInFace(const JPC_ConvexHullShape *in_shape, uint32_t in_face_index);
+
+JPC_API uint32_t
+JPC_ConvexHullShape_GetFaceVertices(const JPC_ConvexHullShape *in_shape,
+                                    uint32_t in_face_index,
+                                    uint32_t in_max_vertices,
+                                    uint32_t *out_vertices);
 //--------------------------------------------------------------------------------------------------
 //
 // JPC_ConstraintSettings

--- a/libs/zphysics/src/zphysics.zig
+++ b/libs/zphysics/src/zphysics.zig
@@ -3194,6 +3194,54 @@ pub const Shape = opaque {
 };
 //--------------------------------------------------------------------------------------------------
 //
+// ConvexHullShape (-> Shape)
+//
+//--------------------------------------------------------------------------------------------------
+pub const ConvexHullShape = opaque {
+    pub usingnamespace Shape.Methods(@This());
+
+    pub fn asConvexHullShape(shape: *const Shape) *const ConvexHullShape {
+        assert(shape.getSubType() == .convex_hull);
+        return @as(*const ConvexHullShape, @ptrCast(shape));
+    }
+    pub fn asConvexHullShapeMut(shape: *Shape) *ConvexHullShape {
+        assert(shape.getSubType() == .convex_hull);
+        return @as(*ConvexHullShape, @ptrCast(shape));
+    }
+
+    pub fn getNumPoints(shape: *const ConvexHullShape) u32 {
+        return c.JPC_ConvexHullShape_GetNumPoints(@as(*const c.JPC_ConvexHullShape, @ptrCast(shape)));
+    }
+    pub fn getPoint(shape: *const ConvexHullShape, in_point_index: u32) [3]f32 {
+        var point: [3]f32 = undefined;
+        c.JPC_ConvexHullShape_GetPoint(@as(*const c.JPC_ConvexHullShape, @ptrCast(shape)), in_point_index, &point);
+        return point;
+    }
+
+    pub fn getNumFaces(shape: *const ConvexHullShape) u32 {
+        return c.JPC_ConvexHullShape_GetNumFaces(@as(*const c.JPC_ConvexHullShape, @ptrCast(shape)));
+    }
+    pub fn getNumVerticesInFace(shape: *const ConvexHullShape, in_face_index: u32) u32 {
+        return c.JPC_ConvexHullShape_GetNumVerticesInFace(
+            @as(*const c.JPC_ConvexHullShape, @ptrCast(shape)),
+            in_face_index,
+        );
+    }
+
+    /// out_vertex_buffer points to memory owned by the caller.
+    /// If out_vertex_buffer.len is less than getNumVerticesInFace(in_face_index), not all vertices are returned.
+    /// The return value gives the number of vertices in the face, identical to getNumVerticesInFace(in_face_index).
+    pub fn getFaceVertices(shape: *const ConvexHullShape, in_face_index: u32, out_vertex_buffer: []u32) u32 {
+        return c.JPC_ConvexHullShape_GetFaceVertices(
+            @as(*const c.JPC_ConvexHullShape, @ptrCast(shape)),
+            in_face_index,
+            @as(u32, @intCast(out_vertex_buffer.len)),
+            out_vertex_buffer.ptr,
+        );
+    }
+};
+//--------------------------------------------------------------------------------------------------
+//
 // ConstraintSettings
 //
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Since no other derived classes of Shape had yet been exposed, I did this in the way that I thought best fit the pattern laid out in the rest of zphysics.

If this isn't the way we want to go about exposing derived shape classes (in cases like these where the derived class has added functionality that isn't just an overridden virtual method from Shape), then I'd be happy to redo this in whatever way you might prefer.

As usual, I've tested these functions by using them all in my own project, but that's the extent of it.