### PR TITLE
[zflecs]: Implement `comptime` for generating systems and `system_desc_t` from arbitrarly `fn`

### DIFF
--- a/libs/zflecs/src/tests.zig
+++ b/libs/zflecs/src/tests.zig
@@ -292,6 +292,39 @@ test "zflecs.helloworld" {
     print("Bob's position is ({d}, {d})\n", .{ p.x, p.y });
 }
 
+fn move_system(positions: []Position, velocities: []const Velocity) void {
+    for (positions, velocities) |*p, *v| {
+        p.x += v.x;
+        p.y += v.y;
+    }
+}
+
+test "zflecs.helloworld_systemcomptime" {
+    print("\n", .{});
+
+    const world = ecs.init();
+    defer _ = ecs.fini(world);
+
+    ecs.COMPONENT(world, Position);
+    ecs.COMPONENT(world, Velocity);
+
+    ecs.TAG(world, Eats);
+    ecs.TAG(world, Apples);
+
+    ecs.ADD_SYSTEM(world, "move system", ecs.OnUpdate, move_system);
+
+    const bob = ecs.new_entity(world, "Bob");
+    _ = ecs.set(world, bob, Position, .{ .x = 0, .y = 0 });
+    _ = ecs.set(world, bob, Velocity, .{ .x = 1, .y = 2 });
+    ecs.add_pair(world, bob, ecs.id(Eats), ecs.id(Apples));
+
+    _ = ecs.progress(world, 0);
+    _ = ecs.progress(world, 0);
+
+    const p = ecs.get(world, bob, Position).?;
+    print("Bob's position is ({d}, {d})\n", .{ p.x, p.y });
+}
+
 test "zflecs.try_different_alignments" {
     const world = ecs.init();
     defer _ = ecs.fini(world);

--- a/libs/zflecs/src/tests.zig
+++ b/libs/zflecs/src/tests.zig
@@ -292,7 +292,7 @@ test "zflecs.helloworld" {
 }
 
 fn move_system(positions: []Position, velocities: []const Velocity) void {
-    for (positions, velocities) |*p, *v| {
+    for (positions, velocities) |*p, v| {
         p.x += v.x;
         p.y += v.y;
     }
@@ -304,7 +304,7 @@ fn move_system_with_it(it: *ecs.iter_t, positions: []Position, velocities: []con
     print("Move entities with [{s}]\n", .{type_str});
     defer ecs.os.free(type_str);
 
-    for (positions, velocities) |*p, *v| {
+    for (positions, velocities) |*p, v| {
         p.x += v.x;
         p.y += v.y;
     }

--- a/libs/zflecs/src/tests.zig
+++ b/libs/zflecs/src/tests.zig
@@ -273,10 +273,10 @@ test "zflecs.helloworld" {
     ecs.TAG(world, Apples);
 
     {
-        var system_desc = ecs.SYSTEM_DESC(move);
-        system_desc.query.filter.terms[0] = .{ .id = ecs.id(Position) };
-        system_desc.query.filter.terms[1] = .{ .id = ecs.id(Velocity) };
-        ecs.SYSTEM(world, "move system", ecs.OnUpdate, &system_desc);
+        ecs.ADD_SYSTEM_WITH_FILTERS(world, "move system", ecs.OnUpdate, move, &.{
+            .{ .id = ecs.id(Position) },
+            .{ .id = ecs.id(Velocity) },
+        });
     }
 
     const bob = ecs.new_entity(world, "Bob");

--- a/libs/zflecs/src/zflecs.zig
+++ b/libs/zflecs/src/zflecs.zig
@@ -2364,6 +2364,20 @@ pub fn OBSERVER(
     _ = observer_init(world, observer_desc);
 }
 
+/// Implements a flecs system from function parameters.
+/// For instance, the function below
+/// fn move_system(positions: []Position, velocities: []const Velocity) void {
+///     for (positions, velocities) |*p, *v| {
+///         p.x += v.x;
+///         p.y += v.y;
+///     }
+/// }
+/// Would return the following implementation
+/// fn exec(it: *ecs.iter_t) callconv(.C) void {
+///     const c1 = ecs.field(it, Position, 1).?;
+///     const c2 = ecs.field(it, Velocity, 2).?;
+///     move_system(c1, c2);//probably inlined
+// }
 fn SystemImpl(comptime fn_system: anytype) type {
     return struct {
         fn exec(it: *iter_t) callconv(.C) void {
@@ -2380,6 +2394,7 @@ fn SystemImpl(comptime fn_system: anytype) type {
     };
 }
 
+/// Creates system_desc_t from function parameters
 pub fn SYSTEM_DESC(comptime fn_system: anytype) system_desc_t {
     const system_struct = SystemImpl(fn_system);
 
@@ -2396,6 +2411,7 @@ pub fn SYSTEM_DESC(comptime fn_system: anytype) system_desc_t {
     return system_desc;
 }
 
+/// Creates a system description and adds it to the world, from function parameters
 pub fn ADD_SYSTEM(
     world: *world_t,
     name: [*:0]const u8,

--- a/libs/zflecs/src/zflecs.zig
+++ b/libs/zflecs/src/zflecs.zig
@@ -2466,7 +2466,6 @@ pub fn ADD_SYSTEM_WITH_FILTERS(
     SYSTEM(world, name, phase, &desc);
 }
 
-
 pub fn new_entity(world: *world_t, name: [*:0]const u8) entity_t {
     return entity_init(world, &.{ .name = name });
 }


### PR DESCRIPTION
This PR adds several comptime functions to `zflecs`, mainly allowing more egornomic system implementatinos, and system addition.

In short, it enables users to do this:

```zig
fn move_system(positions: []Position, velocities: []const Velocity) void {
    for (positions, velocities) |*p, v| {
        p.x += v.x;
        p.y += v.y;
    }
}

pub fn main() !void {
    ...
    ecs.ADD_SYSTEM(world, "move system", ecs.OnUpdate, move_system);
    ...
}
```

Which is more more ergonormic and less error prone than using `*iter_t` and defining queries manually on `system_desc_t`. It also marks the query term as readonly (`.In`) if the array is `const`.

This PR also supports passing `*iter_t` if the user wishes. For instance a user could have something like this:

```zig
fn move_system_with_it(it: *ecs.iter_t, positions: []Position, velocities: []const Velocity) void {
    const type_str = ecs.table_str(it.world, it.table).?;
    print("Move entities with [{s}]\n", .{type_str});
    defer ecs.os.free(type_str);

    for (positions, velocities) |*p, v| {
        p.x += v.x;
        p.y += v.y;
    }
}
```

Or define the queries manually like this:

```zig
fn move(it: *ecs.iter_t) callconv(.C) void {
    const p = ecs.field(it, Position, 1).?;
    const v = ecs.field(it, Velocity, 2).?;
    ...
}

pub fn main() !void {
    ...
        ecs.ADD_SYSTEM_WITH_FILTERS(world, "move system", ecs.OnUpdate, move, &.{
            .{ .id = ecs.id(Position) },
            .{ .id = ecs.id(Velocity), .inout = .In },
        });
    ...
}
```




