### PR TITLE
[zd3d12] fixed RenderTargetWriteMask default to be ALL

### DIFF
--- a/libs/zwin32/src/d3d12.zig
+++ b/libs/zwin32/src/d3d12.zig
@@ -904,7 +904,7 @@ pub const RENDER_TARGET_BLEND_DESC = extern struct {
     DestBlendAlpha: BLEND,
     BlendOpAlpha: BLEND_OP,
     LogicOp: LOGIC_OP,
-    RenderTargetWriteMask: UINT8,
+    RenderTargetWriteMask: COLOR_WRITE_ENABLE,
 
     pub fn initDefault() RENDER_TARGET_BLEND_DESC {
         var v = std.mem.zeroes(@This());
@@ -918,7 +918,7 @@ pub const RENDER_TARGET_BLEND_DESC = extern struct {
             .DestBlendAlpha = .ZERO,
             .BlendOpAlpha = .ADD,
             .LogicOp = .NOOP,
-            .RenderTargetWriteMask = 0x0,
+            .RenderTargetWriteMask = COLOR_WRITE_ENABLE.ALL,
         };
         return v;
     }

--- a/samples/audio_experiments/src/audio_experiments.zig
+++ b/samples/audio_experiments/src/audio_experiments.zig
@@ -210,7 +210,6 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         pso_desc.RTVFormats[0] = .R8G8B8A8_UNORM;
         pso_desc.NumRenderTargets = 1;
         pso_desc.DSVFormat = .D32_FLOAT;
-        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .LINE;
         pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/lines.vs.cso", null));
         pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/lines.ps.cso", null));

--- a/samples/audio_playback_test/src/audio_playback_test.zig
+++ b/samples/audio_playback_test/src/audio_playback_test.zig
@@ -266,7 +266,6 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         };
         pso_desc.RTVFormats[0] = .R8G8B8A8_UNORM;
         pso_desc.NumRenderTargets = 1;
-        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .LINE;
         pso_desc.DepthStencilState.DepthEnable = w32.FALSE;
         pso_desc.RasterizerState.AntialiasedLineEnable = w32.TRUE;
@@ -280,7 +279,6 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         var pso_desc = d3d12.GRAPHICS_PIPELINE_STATE_DESC.initDefault();
         pso_desc.RTVFormats[0] = .R8G8B8A8_UNORM;
         pso_desc.NumRenderTargets = 1;
-        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.DepthStencilState.DepthEnable = w32.FALSE;
         pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/image.vs.cso", null));

--- a/samples/bindless/src/bindless.zig
+++ b/samples/bindless/src/bindless.zig
@@ -328,7 +328,6 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         };
         pso_desc.RTVFormats[0] = .R8G8B8A8_UNORM;
         pso_desc.NumRenderTargets = 1;
-        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/mesh_pbr.vs.cso", null));
         pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/mesh_pbr.ps.cso", null));
@@ -350,7 +349,6 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         };
         pso_desc.RTVFormats[0] = .R8G8B8A8_UNORM;
         pso_desc.NumRenderTargets = 1;
-        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.DSVFormat = .D32_FLOAT;
         pso_desc.RasterizerState.CullMode = .FRONT;
         pso_desc.DepthStencilState.DepthFunc = .LESS_EQUAL;
@@ -376,7 +374,6 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         };
         pso_desc.RTVFormats[0] = .R16G16B16A16_FLOAT;
         pso_desc.NumRenderTargets = 1;
-        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.DepthStencilState.DepthEnable = w32.FALSE;
         pso_desc.RasterizerState.CullMode = .FRONT;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;

--- a/samples/common/src/GuiRenderer.zig
+++ b/samples/common/src/GuiRenderer.zig
@@ -84,7 +84,6 @@ pub fn init(
         };
         pso_desc.RTVFormats[0] = .R8G8B8A8_UNORM;
         pso_desc.NumRenderTargets = 1;
-        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.SampleDesc = .{ .Count = num_msaa_samples, .Quality = 0 };
         pso_desc.VS = d3d12.SHADER_BYTECODE.init(common.readContentDirFileAlloc(arena, content_dir, "shaders/imgui.vs.cso", null) catch unreachable);

--- a/samples/directml_convolution_test/src/directml_convolution_test.zig
+++ b/samples/directml_convolution_test/src/directml_convolution_test.zig
@@ -93,7 +93,6 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         var pso_desc = d3d12.GRAPHICS_PIPELINE_STATE_DESC.initDefault();
         pso_desc.RTVFormats[0] = .R8G8B8A8_UNORM;
         pso_desc.NumRenderTargets = 1;
-        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.DepthStencilState.DepthEnable = w32.FALSE;
         pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/draw_texture.vs.cso", null));

--- a/samples/mesh_shader_test/src/mesh_shader_test.zig
+++ b/samples/mesh_shader_test/src/mesh_shader_test.zig
@@ -277,7 +277,6 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         pso_desc.RTVFormats[0] = .R8G8B8A8_UNORM;
         pso_desc.NumRenderTargets = 1;
         pso_desc.DSVFormat = .D32_FLOAT;
-        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.SampleDesc = .{ .Count = 1, .Quality = 0 };
         pso_desc.MS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/mesh_shader.ms.cso", null));
@@ -291,7 +290,6 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         pso_desc.RTVFormats[0] = .R8G8B8A8_UNORM;
         pso_desc.NumRenderTargets = 1;
         pso_desc.DSVFormat = .D32_FLOAT;
-        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.SampleDesc = .{ .Count = 1, .Quality = 0 };
         pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/vertex_shader.vs.cso", null));
@@ -313,7 +311,6 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         };
         pso_desc.RTVFormats[0] = .R8G8B8A8_UNORM;
         pso_desc.NumRenderTargets = 1;
-        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.DSVFormat = .D32_FLOAT;
         pso_desc.SampleDesc = .{ .Count = 1, .Quality = 0 };

--- a/samples/minimal_d3d12/src/minimal_d3d12.zig
+++ b/samples/minimal_d3d12/src/minimal_d3d12.zig
@@ -104,7 +104,6 @@ pub fn main() !void {
         pso_desc.DepthStencilState.DepthEnable = w32.FALSE;
         pso_desc.RTVFormats[0] = .R8G8B8A8_UNORM;
         pso_desc.NumRenderTargets = 1;
-        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.VS = .{ .pShaderBytecode = vs_cso, .BytecodeLength = vs_cso.len };
         pso_desc.PS = .{ .pShaderBytecode = ps_cso, .BytecodeLength = ps_cso.len };

--- a/samples/minimal_glfw_d3d12/src/minimal_glfw_d3d12.zig
+++ b/samples/minimal_glfw_d3d12/src/minimal_glfw_d3d12.zig
@@ -41,7 +41,6 @@ pub fn main() !void {
         });
         pso_desc.RTVFormats[0] = .R8G8B8A8_UNORM;
         pso_desc.NumRenderTargets = 1;
-        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "minimal_glfw_d3d12.vs.cso", null));
         pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "minimal_glfw_d3d12.ps.cso", null));

--- a/samples/rasterization/src/rasterization.zig
+++ b/samples/rasterization/src/rasterization.zig
@@ -160,7 +160,6 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         };
         pso_desc.RTVFormats[0] = .R8G8B8A8_UNORM;
         pso_desc.NumRenderTargets = 1;
-        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.DSVFormat = .D32_FLOAT;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.RasterizerState.FillMode = .WIREFRAME;

--- a/samples/simple_raytracer/src/simple_raytracer.zig
+++ b/samples/simple_raytracer/src/simple_raytracer.zig
@@ -477,7 +477,6 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         var pso_desc = d3d12.GRAPHICS_PIPELINE_STATE_DESC.initDefault();
         pso_desc.RTVFormats[0] = .R8G8B8A8_UNORM;
         pso_desc.NumRenderTargets = 1;
-        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.DSVFormat = .D32_FLOAT;
         pso_desc.DepthStencilState.DepthFunc = .LESS_EQUAL;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
@@ -491,7 +490,7 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         var pso_desc = d3d12.GRAPHICS_PIPELINE_STATE_DESC.initDefault();
         pso_desc.RTVFormats[0] = .UNKNOWN;
         pso_desc.NumRenderTargets = 0;
-        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0x0;
+        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = .{};
         pso_desc.DSVFormat = .D32_FLOAT;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/z_pre_pass.vs.cso"));
@@ -504,7 +503,6 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         var pso_desc = d3d12.GRAPHICS_PIPELINE_STATE_DESC.initDefault();
         pso_desc.RTVFormats[0] = .R32G32B32A32_FLOAT;
         pso_desc.NumRenderTargets = 1;
-        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.DSVFormat = .D32_FLOAT;
         pso_desc.DepthStencilState.DepthWriteMask = .ZERO;
         pso_desc.DepthStencilState.DepthFunc = .LESS_EQUAL;

--- a/samples/textured_quad/src/textured_quad.zig
+++ b/samples/textured_quad/src/textured_quad.zig
@@ -60,7 +60,6 @@ const DemoState = struct {
             var pso_desc = d3d12.GRAPHICS_PIPELINE_STATE_DESC.initDefault();
             pso_desc.RTVFormats[0] = .R8G8B8A8_UNORM;
             pso_desc.NumRenderTargets = 1;
-            pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
             pso_desc.PrimitiveTopologyType = .TRIANGLE;
             pso_desc.RasterizerState.CullMode = .NONE;
             pso_desc.DepthStencilState.DepthEnable = w32.FALSE;

--- a/samples/triangle/src/triangle.zig
+++ b/samples/triangle/src/triangle.zig
@@ -50,7 +50,6 @@ pub fn main() !void {
         };
         pso_desc.RTVFormats[0] = .R8G8B8A8_UNORM;
         pso_desc.NumRenderTargets = 1;
-        pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
         pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/triangle.vs.cso", null));
         pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/triangle.ps.cso", null));


### PR DESCRIPTION
According to https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ns-d3d12-d3d12_render_target_blend_desc

`RENDER_TARGET_BLEND_DESC.RenderTargetWriteMask` is the type of `COLOR_WRITE_ENABLE` and defaults to `ALL`.

This explains why there were a bunch of extra `pso_desc.BlendState.RenderTarget[0].RenderTargetWriteMask = 0xf` in our samples, while other d3d12 hello triangles used the default `BLEND_DESC`, which in turn used default `RENDER_TARGET_BLEND_DESC`