### PR TITLE
Typo in zglfw example

### DIFF
--- a/libs/zglfw/README.md
+++ b/libs/zglfw/README.md
@@ -25,7 +25,7 @@ pub fn build(b: *std.Build) void {
 
 Now in your code you may import and use `zglfw`:
 ```zig
-const zglfw = @import("zglfw");
+const glfw = @import("zglfw");
 
 pub fn main() !void {
     try glfw.init();


### PR DESCRIPTION
The import uses the name `zglfw` but the code in`main()` refers to `glfw`.