### PR TITLE
Make zopengl compatible with Zig 0.12.0

### DIFF
--- a/libs/zopengl/src/zopengl.zig
+++ b/libs/zopengl/src/zopengl.zig
@@ -1008,7 +1008,7 @@ fn getProcAddress(comptime T: type, proc_name: [:0]const u8) !T {
 // C exports
 //
 //--------------------------------------------------------------------------------------------------
-const linkage: @import("std").builtin.GlobalLinkage = .Strong;
+const linkage: @import("std").builtin.GlobalLinkage = .strong;
 comptime {
     //----------------------------------------------------------------------------------------------
     // OpenGL 1.0 (Core Profile)


### PR DESCRIPTION
The Linkage enum values are written in lowercase in Zig 0.12.0
Without this change, there is a compile error.