### PR TITLE
[zd3d12] more helper functions

### DIFF
--- a/libs/zd3d12/README.md
+++ b/libs/zd3d12/README.md
@@ -2,20 +2,21 @@
 
 ## Features
 
-* Basic DirectX 12 context management (descriptor heaps, memory heaps, swapchain, CPU and GPU sync, etc.)
-* Basic DirectX 12 resource management (handle-based resources and pipelines)
-* Basic resource barriers management with simple state-tracking
-* Transient and persistent descriptor allocation
-* Fast image loading using WIC (Windows Imaging Component)
-* Helpers for uploading data to the GPU
-* Fast mipmap generator running on the GPU
-* Interop with Direct2D and DirectWrite for high-quality vector graphics and text rendering (optional)
+- Basic DirectX 12 context management (descriptor heaps, memory heaps, swapchain, CPU and GPU sync, etc.)
+- Basic DirectX 12 resource management (handle-based resources and pipelines)
+- Basic resource barriers management with simple state-tracking
+- Transient and persistent descriptor allocation
+- Fast image loading using WIC (Windows Imaging Component)
+- Helpers for uploading data to the GPU
+- Fast mipmap generator running on the GPU
+- Interop with Direct2D and DirectWrite for high-quality vector graphics and text rendering (optional)
 
 Example programs: https://github.com/michal-z/zig-gamedev/tree/main/samples/intro
 
 ## Getting started
 
 Copy `zd3d12` and `zwin32` to a subdirectory of your project and and add the following to your `build.zig.zon` .dependencies:
+
 ```zig
     .zd3d12 = .{ .path = "libs/zd3d12" },
     .zwin32 = .{ .path = "libs/zwin32" },
@@ -61,7 +62,7 @@ pub fn main() !void {
 
         gctx.cmdlist.OMSetRenderTargets(
             1,
-            &[_]d3d12.CPU_DESCRIPTOR_HANDLE{back_buffer.descriptor_handle},
+            &.{back_buffer.descriptor_handle},
             w32.TRUE,
             null,
         );

--- a/libs/zd3d12/src/zd3d12.zig
+++ b/libs/zd3d12/src/zd3d12.zig
@@ -553,7 +553,7 @@ pub const GraphicsContext = struct {
                 .{ .DEBUG = enable_debug_layer, .BGRA_SUPPORT = true },
                 null,
                 0,
-                &[_]*w32.IUnknown{@as(*w32.IUnknown, @ptrCast(gctx.cmdqueue))},
+                &.{@as(*w32.IUnknown, @ptrCast(gctx.cmdqueue))},
                 1,
                 0,
                 @as(*?*d3d11.IDevice, @ptrCast(&device11)),
@@ -716,22 +716,26 @@ pub const GraphicsContext = struct {
         gctx.is_cmdlist_opened = true;
         gctx.cmdlist.SetDescriptorHeaps(
             1,
-            &[_]*d3d12.IDescriptorHeap{gctx.cbv_srv_uav_gpu_heaps[0].heap.?},
+            &.{gctx.cbv_srv_uav_gpu_heaps[0].heap.?},
         );
-        gctx.cmdlist.RSSetViewports(1, &[_]d3d12.VIEWPORT{.{
-            .TopLeftX = 0.0,
-            .TopLeftY = 0.0,
-            .Width = @as(f32, @floatFromInt(gctx.viewport_width)),
-            .Height = @as(f32, @floatFromInt(gctx.viewport_height)),
-            .MinDepth = 0.0,
-            .MaxDepth = 1.0,
-        }});
-        gctx.cmdlist.RSSetScissorRects(1, &[_]d3d12.RECT{.{
-            .left = 0,
-            .top = 0,
-            .right = @as(c_long, @intCast(gctx.viewport_width)),
-            .bottom = @as(c_long, @intCast(gctx.viewport_height)),
-        }});
+        gctx.cmdlist.RSSetViewports(1, &.{
+            .{
+                .TopLeftX = 0.0,
+                .TopLeftY = 0.0,
+                .Width = @as(f32, @floatFromInt(gctx.viewport_width)),
+                .Height = @as(f32, @floatFromInt(gctx.viewport_height)),
+                .MinDepth = 0.0,
+                .MaxDepth = 1.0,
+            },
+        });
+        gctx.cmdlist.RSSetScissorRects(1, &.{
+            .{
+                .left = 0,
+                .top = 0,
+                .right = @as(c_long, @intCast(gctx.viewport_width)),
+                .bottom = @as(c_long, @intCast(gctx.viewport_height)),
+            },
+        });
         gctx.current_pipeline = .{};
     }
 
@@ -766,7 +770,7 @@ pub const GraphicsContext = struct {
         gctx.flushGpuCommands();
 
         gctx.d2d.?.device11on12.AcquireWrappedResources(
-            &[_]*d3d11.IResource{gctx.d2d.?.swapbuffers11[gctx.back_buffer_index]},
+            &.{gctx.d2d.?.swapbuffers11[gctx.back_buffer_index]},
             1,
         );
         gctx.d2d.?.context.SetTarget(@as(*d2d1.IImage, @ptrCast(gctx.d2d.?.targets[gctx.back_buffer_index])));
@@ -818,7 +822,7 @@ pub const GraphicsContext = struct {
         hrPanicOnFail(gctx.d2d.?.context.EndDraw(null, null));
 
         gctx.d2d.?.device11on12.ReleaseWrappedResources(
-            &[_]*d3d11.IResource{gctx.d2d.?.swapbuffers11[gctx.back_buffer_index]},
+            &.{gctx.d2d.?.swapbuffers11[gctx.back_buffer_index]},
             1,
         );
         gctx.d2d.?.context11.Flush();
@@ -845,7 +849,7 @@ pub const GraphicsContext = struct {
             gctx.is_cmdlist_opened = false;
             gctx.cmdqueue.ExecuteCommandLists(
                 1,
-                &[_]*d3d12.ICommandList{@as(*d3d12.ICommandList, @ptrCast(gctx.cmdlist))},
+                &.{@as(*d3d12.ICommandList, @ptrCast(gctx.cmdlist))},
             );
         }
     }

--- a/libs/zd3d12/src/zd3d12.zig
+++ b/libs/zd3d12/src/zd3d12.zig
@@ -1900,7 +1900,39 @@ pub const GraphicsContext = struct {
         @memcpy(mapped_slice, source);
     }
 
-    pub fn omSetRenderTargets(
+    pub inline fn clearRenderTargetView(
+        gctx: *GraphicsContext,
+        rt_view: d3d12.CPU_DESCRIPTOR_HANDLE,
+        rgba: *const [4]w32.FLOAT,
+        rects: []const w32.RECT,
+    ) void {
+        gctx.cmdlist.ClearRenderTargetView(
+            rt_view,
+            rgba,
+            rects.len,
+            if (rects.len == 0) null else rects.ptr,
+        );
+    }
+
+    pub inline fn clearDepthStencilView(
+        gctx: *GraphicsContext,
+        ds_view: d3d12.CPU_DESCRIPTOR_HANDLE,
+        clear_flags: d3d12.CLEAR_FLAGS,
+        depth: w32.FLOAT,
+        stencil: w32.UINT8,
+        rects: []const w32.RECT,
+    ) void {
+        gctx.cmdlist.ClearDepthStencilView(
+            ds_view,
+            clear_flags,
+            depth,
+            stencil,
+            rects.len,
+            if (rects.len == 0) null else rects.ptr,
+        );
+    }
+
+    pub inline fn omSetRenderTargets(
         gctx: *GraphicsContext,
         render_target_descriptors: []const d3d12.CPU_DESCRIPTOR_HANDLE,
         single_handle: bool,
@@ -1913,18 +1945,56 @@ pub const GraphicsContext = struct {
             ds_descriptors,
         );
     }
-    pub fn rsSetViewports(gctx: *GraphicsContext, viewports: []const d3d12.VIEWPORT) void {
+    pub inline fn rsSetViewports(gctx: *GraphicsContext, viewports: []const d3d12.VIEWPORT) void {
         gctx.cmdlist.RSSetViewports(@intCast(viewports.len), viewports.ptr);
     }
-    pub fn rsSetScissorRects(gctx: *GraphicsContext, rects: []const d3d12.RECT) void {
+    pub inline fn rsSetScissorRects(gctx: *GraphicsContext, rects: []const d3d12.RECT) void {
         gctx.cmdlist.RSSetScissorRects(@intCast(rects.len), rects.ptr);
     }
-    pub fn iaSetVertexBuffers(gctx: *GraphicsContext, start_slot: w32.UINT, views: []const d3d12.VERTEX_BUFFER_VIEW) void {
+    pub inline fn iaSetPrimitiveTopology(gctx: *GraphicsContext, topology: d3d12.PRIMITIVE_TOPOLOGY) void {
+        gctx.cmdlist.IASetPrimitiveTopology(topology);
+    }
+
+    pub inline fn iaSetVertexBuffers(gctx: *GraphicsContext, start_slot: w32.UINT, views: []const d3d12.VERTEX_BUFFER_VIEW) void {
         gctx.cmdlist.IASetVertexBuffers(start_slot, @intCast(views.len), views.ptr);
     }
-    pub fn setGraphicsRootConstantBufferView(gctx: *GraphicsContext, index: w32.UINT, handle: ResourceHandle) void {
+    pub inline fn iaSetIndexBuffer(gctx: *GraphicsContext, view: ?*const d3d12.INDEX_BUFFER_VIEW) void {
+        gctx.cmdlist.IASetIndexBuffer(view);
+    }
+    pub inline fn setGraphicsRootConstantBufferView(gctx: *GraphicsContext, index: w32.UINT, handle: ResourceHandle) void {
         const resource = gctx.lookupResource(handle).?;
         gctx.cmdlist.SetGraphicsRootConstantBufferView(index, resource.GetGPUVirtualAddress());
+    }
+
+    pub inline fn drawInstanced(
+        gctx: *GraphicsContext,
+        vertex_count_per_instance: w32.UINT,
+        instance_count: w32.UINT,
+        start_vertex_location: w32.UINT,
+        start_instance_location: w32.UINT,
+    ) void {
+        gctx.cmdlist.DrawInstanced(
+            vertex_count_per_instance,
+            instance_count,
+            start_vertex_location,
+            start_instance_location,
+        );
+    }
+    pub inline fn drawIndexedInstanced(
+        gctx: *GraphicsContext,
+        index_count_per_instance: w32.UINT,
+        instance_count: w32.UINT,
+        start_index_location: w32.UINT,
+        base_vertex_location: w32.INT,
+        start_instance_location: w32.UINT,
+    ) void {
+        gctx.cmdlist.DrawIndexedInstanced(
+            index_count_per_instance,
+            instance_count,
+            start_index_location,
+            base_vertex_location,
+            start_instance_location,
+        );
     }
 };
 

--- a/libs/zd3d12/src/zd3d12.zig
+++ b/libs/zd3d12/src/zd3d12.zig
@@ -7,6 +7,7 @@ const dxgi = zwin32.dxgi;
 const d3d11 = zwin32.d3d11;
 const d3d12 = zwin32.d3d12;
 const d3d12d = zwin32.d3d12d;
+const d3d = zwin32.d3d;
 const d2d1 = zwin32.d2d1;
 const d3d11on12 = zwin32.d3d11on12;
 const dds_loader = zwin32.dds_loader;
@@ -914,6 +915,15 @@ pub const GraphicsContext = struct {
         return resource.?.desc;
     }
 
+    pub fn checkFeatureSupport(gctx: *GraphicsContext, comptime feature: d3d12.FEATURE, data: anytype) HResultError!void {
+        const Data = @TypeOf(data);
+        const FeatureData = feature.Data();
+        if (Data != FeatureData) {
+            @compileError("expected " ++ @typeName(FeatureData) ++ " but was " ++ @typeName(Data));
+        }
+        try hrErrorOnFail(gctx.device.CheckFeatureSupport(feature, @constCast(@ptrCast(&data)), @sizeOf(FeatureData)));
+    }
+
     pub fn createCommittedResource(
         gctx: *GraphicsContext,
         heap_type: d3d12.HEAP_TYPE,
@@ -1003,23 +1013,13 @@ pub const GraphicsContext = struct {
             d3d12.RESOURCE_STATES.GENERIC_READ,
             null,
         );
-        const resource = gctx.lookupResource(resource_handle).?;
-        {
-            var mapped_buffer: [*]u8 = undefined;
-            try hrErrorOnFail(resource.Map(
-                0,
-                &.{ .Begin = 0, .End = 0 },
-                @ptrCast(&mapped_buffer),
-            ));
-            defer resource.Unmap(0, null);
-            const mapped_slice = std.mem.bytesAsSlice(T, mapped_buffer[0..buffer_length]);
-            @memcpy(mapped_slice, vertices);
-        }
+
+        try gctx.writeResource(T, resource_handle, vertices);
 
         return .{
             .resource = resource_handle,
             .view = .{
-                .BufferLocation = resource.GetGPUVirtualAddress(),
+                .BufferLocation = gctx.lookupResource(resource_handle).?.GetGPUVirtualAddress(),
                 .StrideInBytes = @sizeOf(T),
                 .SizeInBytes = buffer_length,
             },
@@ -1043,23 +1043,13 @@ pub const GraphicsContext = struct {
             d3d12.RESOURCE_STATES.GENERIC_READ,
             null,
         );
-        const resource = gctx.lookupResource(resource_handle).?;
-        {
-            var mapped_buffer: [*]u8 = undefined;
-            try hrErrorOnFail(resource.Map(
-                0,
-                &.{ .Begin = 0, .End = 0 },
-                @ptrCast(&mapped_buffer),
-            ));
-            defer resource.Unmap(0, null);
-            const mapped_slice = std.mem.bytesAsSlice(T, mapped_buffer[0..buffer_length]);
-            @memcpy(mapped_slice, vertex_indices);
-        }
+
+        try gctx.writeResource(T, resource_handle, vertex_indices);
 
         return .{
             .resource = resource_handle,
             .view = .{
-                .BufferLocation = resource.GetGPUVirtualAddress(),
+                .BufferLocation = gctx.lookupResource(resource_handle).?.GetGPUVirtualAddress(),
                 .Format = switch (T) {
                     u16 => .R16_UINT,
                     u32 => .R32_UINT,
@@ -1094,6 +1084,31 @@ pub const GraphicsContext = struct {
         const cpu_handle = gctx.allocateCpuDescriptors(.CBV_SRV_UAV, 1);
 
         gctx.device.CreateUnorderedAccessView(resource, counter_resource, desc, cpu_handle);
+
+        return cpu_handle;
+    }
+
+    pub fn allocRenderTargetView(
+        gctx: *GraphicsContext,
+        handle: ResourceHandle,
+        desc: ?*const d3d12.RENDER_TARGET_VIEW_DESC,
+    ) d3d12.CPU_DESCRIPTOR_HANDLE {
+        const resource = gctx.lookupResource(handle).?;
+        const cpu_handle = gctx.allocateCpuDescriptors(.RTV, 1);
+
+        gctx.device.CreateRenderTargetView(resource, desc, cpu_handle);
+
+        return cpu_handle;
+    }
+    pub fn allocDepthStencilView(
+        gctx: *GraphicsContext,
+        handle: ResourceHandle,
+        desc: ?*const d3d12.DEPTH_STENCIL_VIEW_DESC,
+    ) d3d12.CPU_DESCRIPTOR_HANDLE {
+        const resource = gctx.lookupResource(handle).?;
+        const cpu_handle = gctx.allocateCpuDescriptors(.DSV, 1);
+
+        gctx.device.CreateDepthStencilView(resource, desc, cpu_handle);
 
         return cpu_handle;
     }
@@ -1846,6 +1861,71 @@ pub const GraphicsContext = struct {
 
         return texture;
     }
+
+    pub fn createRootSignature(
+        gctx: *GraphicsContext,
+        node_mask: w32.UINT,
+        signature: *d3d.IBlob,
+    ) HResultError!*d3d12.IRootSignature {
+        var root_signature: *d3d12.IRootSignature = undefined;
+        try hrErrorOnFail(gctx.device.CreateRootSignature(
+            node_mask,
+            signature.GetBufferPointer(),
+            signature.GetBufferSize(),
+            &d3d12.IID_IRootSignature,
+            @ptrCast(&root_signature),
+        ));
+        return root_signature;
+    }
+
+    pub fn writeResource(
+        gctx: *GraphicsContext,
+        comptime T: type,
+        destination: ResourceHandle,
+        source: []const T,
+    ) HResultError!void {
+        if (source.len == 0) {
+            return;
+        }
+        const resource = gctx.lookupResource(destination).?;
+        var mapped_buffer: [*]u8 = undefined;
+        try zwin32.hrErrorOnFail(resource.Map(
+            0,
+            &.{ .Begin = 0, .End = 0 },
+            @ptrCast(&mapped_buffer),
+        ));
+        defer resource.Unmap(0, null);
+        const byte_length = source.len * @sizeOf(T);
+        const mapped_slice = std.mem.bytesAsSlice(T, mapped_buffer[0..byte_length]);
+        @memcpy(mapped_slice, source);
+    }
+
+    pub fn omSetRenderTargets(
+        gctx: *GraphicsContext,
+        render_target_descriptors: []const d3d12.CPU_DESCRIPTOR_HANDLE,
+        single_handle: bool,
+        ds_descriptors: ?*const d3d12.CPU_DESCRIPTOR_HANDLE,
+    ) void {
+        gctx.cmdlist.OMSetRenderTargets(
+            @intCast(render_target_descriptors.len),
+            render_target_descriptors.ptr,
+            if (single_handle) w32.TRUE else w32.FALSE,
+            ds_descriptors,
+        );
+    }
+    pub fn rsSetViewports(gctx: *GraphicsContext, viewports: []const d3d12.VIEWPORT) void {
+        gctx.cmdlist.RSSetViewports(@intCast(viewports.len), viewports.ptr);
+    }
+    pub fn rsSetScissorRects(gctx: *GraphicsContext, rects: []const d3d12.RECT) void {
+        gctx.cmdlist.RSSetScissorRects(@intCast(rects.len), rects.ptr);
+    }
+    pub fn iaSetVertexBuffers(gctx: *GraphicsContext, start_slot: w32.UINT, views: []const d3d12.VERTEX_BUFFER_VIEW) void {
+        gctx.cmdlist.IASetVertexBuffers(start_slot, @intCast(views.len), views.ptr);
+    }
+    pub fn setGraphicsRootConstantBufferView(gctx: *GraphicsContext, index: w32.UINT, handle: ResourceHandle) void {
+        const resource = gctx.lookupResource(handle).?;
+        gctx.cmdlist.SetGraphicsRootConstantBufferView(index, resource.GetGPUVirtualAddress());
+    }
 };
 
 pub const MipmapGenerator = struct {
@@ -2409,3 +2489,9 @@ const GpuMemoryHeap = struct {
         return .{ .cpu_slice = cpu_slice, .gpu_base = gpu_base };
     }
 };
+
+pub fn serializeVersionedRootSignature(root_signature_desc: *const d3d12.VERSIONED_ROOT_SIGNATURE_DESC) HResultError!*d3d.IBlob {
+    var signature: ?*d3d.IBlob = undefined;
+    try hrErrorOnFail(d3d12.SerializeVersionedRootSignature(root_signature_desc, &signature, null));
+    return signature.?;
+}

--- a/libs/zgpu/README.md
+++ b/libs/zgpu/README.md
@@ -6,17 +6,18 @@ Supports Windows 10+ (DirectX 12), macOS 12+ (Metal) and Linux (Vulkan).
 
 ## Features:
 
-* Zero-overhead wgpu API bindings ([source code](https://github.com/michal-z/zig-gamedev/blob/main/libs/zgpu/src/wgpu.zig))
-* Uniform buffer pool for fast CPU->GPU transfers
-* Resource pools and handle-based GPU resources
-* Async shader compilation
-* GPU mipmap generator
+- Zero-overhead wgpu API bindings ([source code](https://github.com/michal-z/zig-gamedev/blob/main/libs/zgpu/src/wgpu.zig))
+- Uniform buffer pool for fast CPU->GPU transfers
+- Resource pools and handle-based GPU resources
+- Async shader compilation
+- GPU mipmap generator
 
 For more details please see below.
 
 ## Getting started
 
 Copy `zgpu`, `zpool` and `system-sdk` to a subdirectory of your project and add the following to your `build.zig.zon` dependencies:
+
 ```zig
 .{
     .zgpu = .{ .path = libs/zgpu" },
@@ -35,7 +36,7 @@ Copy `zgpu`, `zpool` and `system-sdk` to a subdirectory of your project and add 
     },
     .dawn_aarch64_macos = .{
         .url = "https://github.com/michal-z/webgpu_dawn-aarch64-macos/archive/d2360cdfff0cf4a780cb77aa47c57aca03cc6dfe.tar.gz",
-        .hash = "12201fe677e9c7cfb8984a36446b329d5af23d03dc1e4f79a853399529e523a007fa"
+        .hash = "12201fe677e9c7cfb8984a36446b329d5af23d03dc1e4f79a853399529e523a007fa",
     },
     .dawn_x86_64_macos = .{
         .url = "https://github.com/michal-z/webgpu_dawn-x86_64-macos/archive/901716b10b31ce3e0d3fe479326b41e91d59c661.tar.gz",
@@ -45,6 +46,7 @@ Copy `zgpu`, `zpool` and `system-sdk` to a subdirectory of your project and add 
 ```
 
 then in your `build.zig`:
+
 ```zig
 pub fn build(b: *std.Build) void {
     const exe = b.addExecutable(.{ ... });
@@ -59,15 +61,16 @@ pub fn build(b: *std.Build) void {
 }
 ```
 
---------------
+---
+
 ## Sample applications
 
-* [gui test (wgpu)](https://github.com/michal-z/zig-gamedev/tree/main/samples/gui_test_wgpu)
-* [physically based rendering (wgpu)](https://github.com/michal-z/zig-gamedev/tree/main/samples/physically_based_rendering_wgpu)
-* [bullet physics test (wgpu)](https://github.com/michal-z/zig-gamedev/tree/main/samples/bullet_physics_test_wgpu)
-* [procedural mesh (wgpu)](https://github.com/michal-z/zig-gamedev/tree/main/samples/procedural_mesh_wgpu)
-* [textured quad (wgpu)](https://github.com/michal-z/zig-gamedev/tree/main/samples/textured_quad_wgpu)
-* [triangle (wgpu)](https://github.com/michal-z/zig-gamedev/tree/main/samples/triangle_wgpu)
+- [gui test (wgpu)](https://github.com/michal-z/zig-gamedev/tree/main/samples/gui_test_wgpu)
+- [physically based rendering (wgpu)](https://github.com/michal-z/zig-gamedev/tree/main/samples/physically_based_rendering_wgpu)
+- [bullet physics test (wgpu)](https://github.com/michal-z/zig-gamedev/tree/main/samples/bullet_physics_test_wgpu)
+- [procedural mesh (wgpu)](https://github.com/michal-z/zig-gamedev/tree/main/samples/procedural_mesh_wgpu)
+- [textured quad (wgpu)](https://github.com/michal-z/zig-gamedev/tree/main/samples/textured_quad_wgpu)
+- [triangle (wgpu)](https://github.com/michal-z/zig-gamedev/tree/main/samples/triangle_wgpu)
 
 ## Library overview
 
@@ -76,6 +79,7 @@ Below you can find an overview of main `zgpu` features.
 ### Compile-time options
 
 You can override default options in your `build.zig`:
+
 ```zig
 pub fn build(b: *std.Build) void {
     ...
@@ -103,7 +107,9 @@ pub fn build(b: *std.Build) void {
 ```
 
 ### Graphics Context
+
 Create a `GraphicsContext` using a `WindowProvider`. For example, using [zglfw](https://github.com/zig-gamedev):
+
 ```zig
 const gctx = try zgpu.GraphicsContext.create(
     allocator,
@@ -126,9 +132,9 @@ const gctx = try zgpu.GraphicsContext.create(
 
 ### Uniforms
 
-* Implemented as a uniform buffer pool
-* Easy to use
-* Efficient - only one copy operation per frame
+- Implemented as a uniform buffer pool
+- Easy to use
+- Efficient - only one copy operation per frame
 
 ```zig
 struct DrawUniforms = extern struct {
@@ -146,13 +152,13 @@ gctx.submit(...); // Injects *one* copy operation to transfer *all* allocated un
 
 ### Resource pools
 
-* Every GPU resource is identified by 32-bit integer handle
-* All resources are stored in one system
-* We keep basic info about each resource (size of the buffer, format of the texture, etc.)
-* You can always check if resource is valid (very useful for async operations)
-* System keeps basic info about resource dependencies, for example, `TextureViewHandle` knows about its
-parent texture and becomes invalid when parent texture becomes invalid; `BindGroupHandle` knows
-about all resources it binds so it becomes invalid if any of those resources become invalid
+- Every GPU resource is identified by 32-bit integer handle
+- All resources are stored in one system
+- We keep basic info about each resource (size of the buffer, format of the texture, etc.)
+- You can always check if resource is valid (very useful for async operations)
+- System keeps basic info about resource dependencies, for example, `TextureViewHandle` knows about its
+  parent texture and becomes invalid when parent texture becomes invalid; `BindGroupHandle` knows
+  about all resources it binds so it becomes invalid if any of those resources become invalid
 
 ```zig
 const buffer_handle = gctx.createBuffer(...);
@@ -168,9 +174,10 @@ if (gctx.isResourceValid(buffer_handle)) {
 gctx.destroyResource(buffer_handle);
 
 ```
+
 ### Async shader compilation
 
-* Thanks to resource pools and resources identified by handles we can easily async compile all our shaders
+- Thanks to resource pools and resources identified by handles we can easily async compile all our shaders
 
 ```zig
 const DemoState = struct {
@@ -195,12 +202,12 @@ pass: {
 
 ### Mipmap generation on the GPU
 
-* wgpu API does not provide mipmap generator
-* zgpu provides decent mipmap generator implemented in a compute shader
-* It supports 2D textures, array textures and cubemap textures of any format
-(`rgba8_unorm`, `rg16_float`, `rgba32_float`, etc.)
-* Currently it requires that: `texture_width == texture_height and isPowerOfTwo(texture_width)`
-* It takes ~260 microsec to generate all mips for 1024x1024 `rgba8_unorm` texture on GTX 1660
+- wgpu API does not provide mipmap generator
+- zgpu provides decent mipmap generator implemented in a compute shader
+- It supports 2D textures, array textures and cubemap textures of any format
+  (`rgba8_unorm`, `rg16_float`, `rgba32_float`, etc.)
+- Currently it requires that: `texture_width == texture_height and isPowerOfTwo(texture_width)`
+- It takes ~260 microsec to generate all mips for 1024x1024 `rgba8_unorm` texture on GTX 1660
 
 ```zig
 // Usage:

--- a/libs/zgpu/src/zgpu.zig
+++ b/libs/zgpu/src/zgpu.zig
@@ -70,7 +70,7 @@ pub const WindowProvider = struct {
 
 pub const GraphicsContextOptions = struct {
     present_mode: wgpu.PresentMode = .fifo,
-    required_features: []const wgpu.FeatureName = &[_]wgpu.FeatureName{},
+    required_features: []const wgpu.FeatureName = &.{},
 };
 
 pub const GraphicsContext = struct {
@@ -986,7 +986,7 @@ pub const GraphicsContext = struct {
             });
             defer gctx.releaseResource(texture_view);
 
-            const bind_group = gctx.createBindGroup(mipgen.bind_group_layout, &[_]BindGroupEntryInfo{
+            const bind_group = gctx.createBindGroup(mipgen.bind_group_layout, &.{
                 .{ .binding = 0, .buffer_handle = gctx.uniforms.buffer, .offset = 0, .size = 8 },
                 .{ .binding = 1, .texture_view_handle = texture_view },
                 .{ .binding = 2, .texture_view_handle = mipgen.scratch_texture_views[0] },

--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -1657,7 +1657,7 @@ pub fn comboFromEnum(
         else => @compileError("Error: current_item must be a pointer-to-an-enum, not a " ++ @TypeOf(current_item)),
     };
 
-    const FieldNameIndex = std.meta.Tuple(&[_]type{ []const u8, i32 });
+    const FieldNameIndex = std.meta.Tuple(&.{ []const u8, i32 });
     comptime var item_names: [:0]const u8 = "";
     comptime var field_name_to_index_list: [enum_type_info.fields.len]FieldNameIndex = undefined;
     comptime var index_to_enum: [enum_type_info.fields.len]EnumType = undefined;

--- a/libs/zopenvr/src/system.zig
+++ b/libs/zopenvr/src/system.zig
@@ -231,7 +231,7 @@ pub fn getEventTypeNameFromEnum(self: Self, event_type: common.EventType) [:0]co
 pub fn getHiddenAreaMesh(self: Self, eye: common.Eye, mesh_type: common.HiddenAreaMeshType) []const common.Vector2 {
     const mesh = self.function_table.GetHiddenAreaMesh(eye, mesh_type);
     return if (mesh.triangle_count == 0)
-        &[_]common.Vector2{}
+        &.{}
     else
         mesh.vertex_data[0..mesh.triangle_count];
 }

--- a/libs/zwin32/src/d3d12.zig
+++ b/libs/zwin32/src/d3d12.zig
@@ -398,7 +398,7 @@ pub const ROOT_SIGNATURE_FLAGS = packed struct(UINT) {
 };
 
 pub const ROOT_SIGNATURE_DESC = extern struct {
-    NumParamenters: UINT,
+    NumParameters: UINT,
     pParameters: ?[*]const ROOT_PARAMETER,
     NumStaticSamplers: UINT,
     pStaticSamplers: ?[*]const STATIC_SAMPLER_DESC,
@@ -467,11 +467,21 @@ pub const ROOT_PARAMETER1 = extern struct {
 };
 
 pub const ROOT_SIGNATURE_DESC1 = extern struct {
-    NumParamenters: UINT,
+    NumParameters: UINT,
     pParameters: ?[*]const ROOT_PARAMETER1,
     NumStaticSamplers: UINT,
     pStaticSamplers: ?[*]const STATIC_SAMPLER_DESC,
     Flags: ROOT_SIGNATURE_FLAGS,
+
+    pub fn init(parameters: []const ROOT_PARAMETER1, static_samplers: []const STATIC_SAMPLER_DESC, flags: ROOT_SIGNATURE_FLAGS) ROOT_SIGNATURE_DESC1 {
+        return .{
+            .NumParameters = @intCast(parameters.len),
+            .pParameters = if (parameters.len > 0) parameters.ptr else null,
+            .NumStaticSamplers = @intCast(static_samplers.len),
+            .pStaticSamplers = if (static_samplers.len > 0) static_samplers.ptr else null,
+            .Flags = flags,
+        };
+    }
 };
 
 pub const ROOT_SIGNATURE_VERSION = enum(UINT) {
@@ -485,6 +495,24 @@ pub const VERSIONED_ROOT_SIGNATURE_DESC = extern struct {
         Desc_1_0: ROOT_SIGNATURE_DESC,
         Desc_1_1: ROOT_SIGNATURE_DESC1,
     },
+
+    pub fn initVersion1_0(desc: ROOT_SIGNATURE_DESC) VERSIONED_ROOT_SIGNATURE_DESC {
+        return .{
+            .Version = .VERSION_1_0,
+            .u = .{
+                .Desc_1_0 = desc,
+            },
+        };
+    }
+
+    pub fn initVersion1_1(desc: ROOT_SIGNATURE_DESC1) VERSIONED_ROOT_SIGNATURE_DESC {
+        return .{
+            .Version = .VERSION_1_1,
+            .u = .{
+                .Desc_1_1 = desc,
+            },
+        };
+    }
 };
 
 pub const COMMAND_LIST_TYPE = enum(UINT) {
@@ -1185,6 +1213,20 @@ pub const FEATURE = enum(UINT) {
     OPTIONS9 = 37,
     OPTIONS10 = 39,
     OPTIONS11 = 40,
+
+    pub fn Data(self: FEATURE) type {
+        // enum to type https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ne-d3d12-d3d12_feature#constants
+        return switch (self) {
+            .OPTIONS => FEATURE_DATA_D3D12_OPTIONS,
+            .FORMAT_INFO => FEATURE_DATA_FORMAT_INFO,
+            .SHADER_MODEL => FEATURE_DATA_SHADER_MODEL,
+            .ROOT_SIGNATURE => FEATURE_DATA_ROOT_SIGNATURE,
+            .OPTIONS3 => FEATURE_DATA_D3D12_OPTIONS3,
+            .OPTIONS5 => FEATURE_DATA_D3D12_OPTIONS5,
+            .OPTIONS7 => FEATURE_DATA_D3D12_OPTIONS7,
+            else => @compileError("not implemented"),
+        };
+    }
 };
 
 pub const SHADER_MODEL = enum(UINT) {

--- a/samples/audio_experiments/src/audio_experiments.zig
+++ b/samples/audio_experiments/src/audio_experiments.zig
@@ -424,7 +424,7 @@ fn draw(demo: *DemoState) void {
 
     gctx.cmdlist.OMSetRenderTargets(
         1,
-        &[_]d3d12.CPU_DESCRIPTOR_HANDLE{back_buffer.descriptor_handle},
+        &.{back_buffer.descriptor_handle},
         w32.TRUE,
         &demo.depth_texture_dsv,
     );
@@ -488,11 +488,13 @@ fn draw(demo: *DemoState) void {
                 };
             }
 
-            gctx.cmdlist.IASetVertexBuffers(0, 1, &[_]d3d12.VERTEX_BUFFER_VIEW{.{
-                .BufferLocation = mem.gpu_base,
-                .SizeInBytes = num_vertices * @sizeOf(Pso_Vertex),
-                .StrideInBytes = @sizeOf(Pso_Vertex),
-            }});
+            gctx.cmdlist.IASetVertexBuffers(0, 1, &.{
+                .{
+                    .BufferLocation = mem.gpu_base,
+                    .SizeInBytes = num_vertices * @sizeOf(Pso_Vertex),
+                    .StrideInBytes = @sizeOf(Pso_Vertex),
+                },
+            });
             gctx.cmdlist.DrawInstanced(num_vertices, 1, 0, 0);
         }
     }

--- a/samples/audio_experiments_wgpu/src/audio_experiments_wgpu.zig
+++ b/samples/audio_experiments_wgpu/src/audio_experiments_wgpu.zig
@@ -251,12 +251,14 @@ fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
     });
     defer gctx.releaseResource(uniform_bgl);
 
-    const uniform_bg = gctx.createBindGroup(uniform_bgl, &[_]zgpu.BindGroupEntryInfo{.{
-        .binding = 0,
-        .buffer_handle = gctx.uniforms.buffer,
-        .offset = 0,
-        .size = safe_uniform_size,
-    }});
+    const uniform_bg = gctx.createBindGroup(uniform_bgl, &.{
+        .{
+            .binding = 0,
+            .buffer_handle = gctx.uniforms.buffer,
+            .offset = 0,
+            .size = safe_uniform_size,
+        },
+    });
 
     const depth = createDepthTexture(gctx);
 

--- a/samples/audio_playback_test/src/audio_playback_test.zig
+++ b/samples/audio_playback_test/src/audio_playback_test.zig
@@ -400,7 +400,7 @@ fn draw(demo: *DemoState) void {
 
     gctx.cmdlist.OMSetRenderTargets(
         1,
-        &[_]d3d12.CPU_DESCRIPTOR_HANDLE{back_buffer.descriptor_handle},
+        &.{back_buffer.descriptor_handle},
         w32.TRUE,
         null,
     );
@@ -420,11 +420,13 @@ fn draw(demo: *DemoState) void {
     // Draw audio stream samples.
     gctx.setCurrentPipeline(demo.lines_pso);
     gctx.cmdlist.IASetPrimitiveTopology(.LINESTRIP);
-    gctx.cmdlist.IASetVertexBuffers(0, 1, &[_]d3d12.VERTEX_BUFFER_VIEW{.{
-        .BufferLocation = gctx.lookupResource(demo.lines_buffer).?.GetGPUVirtualAddress(),
-        .SizeInBytes = num_vis_samples * @sizeOf(Vec2),
-        .StrideInBytes = @sizeOf(Vec2),
-    }});
+    gctx.cmdlist.IASetVertexBuffers(0, 1, &.{
+        .{
+            .BufferLocation = gctx.lookupResource(demo.lines_buffer).?.GetGPUVirtualAddress(),
+            .SizeInBytes = num_vis_samples * @sizeOf(Vec2),
+            .StrideInBytes = @sizeOf(Vec2),
+        },
+    });
     gctx.cmdlist.DrawInstanced(num_vis_samples, 1, 0, 0);
 
     demo.guir.draw(gctx);

--- a/samples/bindless/src/bindless.zig
+++ b/samples/bindless/src/bindless.zig
@@ -237,20 +237,24 @@ fn drawToCubeTexture(
     const texture_height = desc.Height >> @as(u5, @intCast(dest_mip_level));
     assert(texture_width == texture_height);
 
-    gctx.cmdlist.RSSetViewports(1, &[_]d3d12.VIEWPORT{.{
-        .TopLeftX = 0.0,
-        .TopLeftY = 0.0,
-        .Width = @as(f32, @floatFromInt(texture_width)),
-        .Height = @as(f32, @floatFromInt(texture_height)),
-        .MinDepth = 0.0,
-        .MaxDepth = 1.0,
-    }});
-    gctx.cmdlist.RSSetScissorRects(1, &[_]d3d12.RECT{.{
-        .left = 0,
-        .top = 0,
-        .right = @as(c_long, @intCast(texture_width)),
-        .bottom = @as(c_long, @intCast(texture_height)),
-    }});
+    gctx.cmdlist.RSSetViewports(1, &.{
+        .{
+            .TopLeftX = 0.0,
+            .TopLeftY = 0.0,
+            .Width = @as(f32, @floatFromInt(texture_width)),
+            .Height = @as(f32, @floatFromInt(texture_height)),
+            .MinDepth = 0.0,
+            .MaxDepth = 1.0,
+        },
+    });
+    gctx.cmdlist.RSSetScissorRects(1, &.{
+        .{
+            .left = 0,
+            .top = 0,
+            .right = @as(c_long, @intCast(texture_width)),
+            .bottom = @as(c_long, @intCast(texture_height)),
+        },
+    });
     gctx.cmdlist.IASetPrimitiveTopology(.TRIANGLELIST);
 
     const zero = Vec3.initZero();
@@ -286,7 +290,7 @@ fn drawToCubeTexture(
 
         gctx.addTransitionBarrier(dest_texture, .{ .RENDER_TARGET = true });
         gctx.flushResourceBarriers();
-        gctx.cmdlist.OMSetRenderTargets(1, &[_]d3d12.CPU_DESCRIPTOR_HANDLE{cube_face_rtv}, w32.TRUE, null);
+        gctx.cmdlist.OMSetRenderTargets(1, &.{cube_face_rtv}, w32.TRUE, null);
         gctx.deallocateAllTempCpuDescriptors(.RTV);
 
         const mem = gctx.allocateUploadMemory(Mat4, 1);
@@ -787,11 +791,13 @@ fn init(allocator: std.mem.Allocator) !DemoState {
 
     gctx.flushResourceBarriers();
 
-    gctx.cmdlist.IASetVertexBuffers(0, 1, &[_]d3d12.VERTEX_BUFFER_VIEW{.{
-        .BufferLocation = gctx.lookupResource(vertex_buffer).?.GetGPUVirtualAddress(),
-        .SizeInBytes = @as(u32, @intCast(gctx.getResourceSize(vertex_buffer))),
-        .StrideInBytes = @sizeOf(Vertex),
-    }});
+    gctx.cmdlist.IASetVertexBuffers(0, 1, &.{
+        .{
+            .BufferLocation = gctx.lookupResource(vertex_buffer).?.GetGPUVirtualAddress(),
+            .SizeInBytes = @as(u32, @intCast(gctx.getResourceSize(vertex_buffer))),
+            .StrideInBytes = @sizeOf(Vertex),
+        },
+    });
     gctx.cmdlist.IASetIndexBuffer(&.{
         .BufferLocation = gctx.lookupResource(index_buffer).?.GetGPUVirtualAddress(),
         .SizeInBytes = @as(u32, @intCast(gctx.getResourceSize(index_buffer))),
@@ -999,7 +1005,7 @@ fn draw(demo: *DemoState) void {
 
     gctx.cmdlist.OMSetRenderTargets(
         1,
-        &[_]d3d12.CPU_DESCRIPTOR_HANDLE{back_buffer.descriptor_handle},
+        &.{back_buffer.descriptor_handle},
         w32.TRUE,
         &demo.depth_texture.view,
     );
@@ -1012,11 +1018,13 @@ fn draw(demo: *DemoState) void {
     gctx.cmdlist.ClearDepthStencilView(demo.depth_texture.view, .{ .DEPTH = true }, 1.0, 0, 0, null);
 
     gctx.cmdlist.IASetPrimitiveTopology(.TRIANGLELIST);
-    gctx.cmdlist.IASetVertexBuffers(0, 1, &[_]d3d12.VERTEX_BUFFER_VIEW{.{
-        .BufferLocation = gctx.lookupResource(demo.vertex_buffer).?.GetGPUVirtualAddress(),
-        .SizeInBytes = @as(u32, @intCast(gctx.getResourceSize(demo.vertex_buffer))),
-        .StrideInBytes = @sizeOf(Vertex),
-    }});
+    gctx.cmdlist.IASetVertexBuffers(0, 1, &.{
+        .{
+            .BufferLocation = gctx.lookupResource(demo.vertex_buffer).?.GetGPUVirtualAddress(),
+            .SizeInBytes = @as(u32, @intCast(gctx.getResourceSize(demo.vertex_buffer))),
+            .StrideInBytes = @sizeOf(Vertex),
+        },
+    });
     gctx.cmdlist.IASetIndexBuffer(&.{
         .BufferLocation = gctx.lookupResource(demo.index_buffer).?.GetGPUVirtualAddress(),
         .SizeInBytes = @as(u32, @intCast(gctx.getResourceSize(demo.index_buffer))),
@@ -1051,7 +1059,7 @@ fn draw(demo: *DemoState) void {
 
         gctx.cmdlist.SetGraphicsRootConstantBufferView(1, mem.gpu_base);
 
-        gctx.setGraphicsRootDescriptorTable(2, &[_]d3d12.CPU_DESCRIPTOR_HANDLE{
+        gctx.setGraphicsRootDescriptorTable(2, &.{
             demo.irradiance_texture.view,
             demo.prefiltered_env_texture.view,
             demo.brdf_integration_texture.view,

--- a/samples/bullet_physics_test_wgpu/src/bullet_physics_test_wgpu.zig
+++ b/samples/bullet_physics_test_wgpu/src/bullet_physics_test_wgpu.zig
@@ -197,12 +197,14 @@ fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
     //
     // Create bind groups.
     //
-    const uniform_bg = gctx.createBindGroup(uniform_bgl, &[_]zgpu.BindGroupEntryInfo{.{
-        .binding = 0,
-        .buffer_handle = gctx.uniforms.buffer,
-        .offset = 0,
-        .size = safe_uniform_size,
-    }});
+    const uniform_bg = gctx.createBindGroup(uniform_bgl, &.{
+        .{
+            .binding = 0,
+            .buffer_handle = gctx.uniforms.buffer,
+            .offset = 0,
+            .size = safe_uniform_size,
+        },
+    });
 
     //
     // Init physics.

--- a/samples/common/src/GuiRenderer.zig
+++ b/samples/common/src/GuiRenderer.zig
@@ -196,14 +196,16 @@ pub fn draw(gui: *GuiRenderer, gctx: *zd3d12.GraphicsContext) void {
     const display_y = draw_data.?.*.DisplayPos.y;
     const display_w = draw_data.?.*.DisplaySize.x;
     const display_h = draw_data.?.*.DisplaySize.y;
-    gctx.cmdlist.RSSetViewports(1, &[_]d3d12.VIEWPORT{.{
-        .TopLeftX = 0.0,
-        .TopLeftY = 0.0,
-        .Width = display_w,
-        .Height = display_h,
-        .MinDepth = 0.0,
-        .MaxDepth = 1.0,
-    }});
+    gctx.cmdlist.RSSetViewports(1, &.{
+        .{
+            .TopLeftX = 0.0,
+            .TopLeftY = 0.0,
+            .Width = display_w,
+            .Height = display_h,
+            .MinDepth = 0.0,
+            .MaxDepth = 1.0,
+        },
+    });
     gctx.cmdlist.IASetPrimitiveTopology(.TRIANGLELIST);
     gctx.setCurrentPipeline(gui.pipeline);
     {
@@ -222,11 +224,13 @@ pub fn draw(gui: *GuiRenderer, gctx: *zd3d12.GraphicsContext) void {
         gctx.cmdlist.SetGraphicsRootConstantBufferView(0, mem.gpu_base);
     }
     gctx.cmdlist.SetGraphicsRootDescriptorTable(1, gctx.copyDescriptorsToGpuHeap(1, gui.font_srv));
-    gctx.cmdlist.IASetVertexBuffers(0, 1, &[_]d3d12.VERTEX_BUFFER_VIEW{.{
-        .BufferLocation = gctx.lookupResource(vb).?.GetGPUVirtualAddress(),
-        .SizeInBytes = num_vertices * @sizeOf(c.ImDrawVert),
-        .StrideInBytes = @sizeOf(c.ImDrawVert),
-    }});
+    gctx.cmdlist.IASetVertexBuffers(0, 1, &.{
+        .{
+            .BufferLocation = gctx.lookupResource(vb).?.GetGPUVirtualAddress(),
+            .SizeInBytes = num_vertices * @sizeOf(c.ImDrawVert),
+            .StrideInBytes = @sizeOf(c.ImDrawVert),
+        },
+    });
     gctx.cmdlist.IASetIndexBuffer(&.{
         .BufferLocation = gctx.lookupResource(ib).?.GetGPUVirtualAddress(),
         .SizeInBytes = num_indices * @sizeOf(c.ImDrawIdx),

--- a/samples/directml_convolution_test/src/directml_convolution_test.zig
+++ b/samples/directml_convolution_test/src/directml_convolution_test.zig
@@ -127,8 +127,8 @@ fn init(allocator: std.mem.Allocator) !DemoState {
             .DataType = .FLOAT16,
             .Flags = .{},
             .DimensionCount = 4,
-            .Sizes = &[_]u32{ 1, 1, image_size, image_size },
-            .Strides = &[_]u32{ image_size * image_size, image_size, image_size, 1 },
+            .Sizes = &.{ 1, 1, image_size, image_size },
+            .Strides = &.{ image_size * image_size, image_size, image_size, 1 },
             .TotalTensorSizeInBytes = image_size * image_size * @sizeOf(f16),
             .GuaranteedBaseOffsetAlignment = 256,
         },
@@ -140,8 +140,8 @@ fn init(allocator: std.mem.Allocator) !DemoState {
             .DataType = .FLOAT16,
             .Flags = .{},
             .DimensionCount = 4,
-            .Sizes = &[_]u32{ 1, 1, image_size - 2, image_size - 2 },
-            .Strides = &[_]u32{ image_size * image_size, image_size, image_size, 1 },
+            .Sizes = &.{ 1, 1, image_size - 2, image_size - 2 },
+            .Strides = &.{ image_size * image_size, image_size, image_size, 1 },
             .TotalTensorSizeInBytes = image_size * image_size * @sizeOf(f16),
             .GuaranteedBaseOffsetAlignment = 256,
         },
@@ -153,7 +153,7 @@ fn init(allocator: std.mem.Allocator) !DemoState {
             .DataType = .FLOAT16,
             .Flags = .{},
             .DimensionCount = 4,
-            .Sizes = &[_]u32{ 1, 1, 3, 3 },
+            .Sizes = &.{ 1, 1, 3, 3 },
             .Strides = null,
             .TotalTensorSizeInBytes = std.mem.alignForward(
                 w32.UINT64,
@@ -175,11 +175,11 @@ fn init(allocator: std.mem.Allocator) !DemoState {
                 .Mode = .CONVOLUTION,
                 .Direction = .FORWARD,
                 .DimensionCount = 2,
-                .Strides = &[_]u32{ 1, 1 },
-                .Dilations = &[_]u32{ 1, 1 },
-                .StartPadding = &[_]u32{ 0, 0 },
-                .EndPadding = &[_]u32{ 0, 0 },
-                .OutputPadding = &[_]u32{ 0, 0 },
+                .Strides = &.{ 1, 1 },
+                .Dilations = &.{ 1, 1 },
+                .StartPadding = &.{ 0, 0 },
+                .EndPadding = &.{ 0, 0 },
+                .OutputPadding = &.{ 0, 0 },
                 .GroupCount = 1,
                 .FusedActivation = null,
             },
@@ -335,7 +335,7 @@ fn init(allocator: std.mem.Allocator) !DemoState {
     gctx.flushResourceBarriers();
 
     gctx.setCurrentPipeline(texture_to_buffer_pso);
-    gctx.setComputeRootDescriptorTable(0, &[_]d3d12.CPU_DESCRIPTOR_HANDLE{
+    gctx.setComputeRootDescriptorTable(0, &.{
         image_texture_srv,
         input_buffer_uav,
     });
@@ -405,7 +405,7 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         };
         offset += conv_info.PersistentResourceSize;
 
-        init_dtbl.BindOutputs(1, &[_]dml.BINDING_DESC{binding0});
+        init_dtbl.BindOutputs(1, &.{binding0});
     }
 
     dml_cmd_recorder.RecordDispatch(
@@ -498,7 +498,7 @@ fn dispatchConvOperator(demo: *DemoState) void {
     }
 
     // Bind input buffers.
-    demo.conv_op_state.dtbl.BindInputs(3, &[_]dml.BINDING_DESC{
+    demo.conv_op_state.dtbl.BindInputs(3, &.{
         .{ // InputTensor
             .Type = .BUFFER,
             .Desc = &dml.BUFFER_BINDING{
@@ -522,7 +522,7 @@ fn dispatchConvOperator(demo: *DemoState) void {
     });
 
     // Bind output buffer.
-    demo.conv_op_state.dtbl.BindOutputs(1, &[_]dml.BINDING_DESC{.{
+    demo.conv_op_state.dtbl.BindOutputs(1, &.{.{
         .Type = .BUFFER,
         .Desc = &dml.BUFFER_BINDING{
             .Buffer = gctx.lookupResource(demo.output_buffer).?,
@@ -542,7 +542,7 @@ fn dispatchBarriers(demo: *DemoState) void {
     var gctx = &demo.gctx;
     gctx.cmdlist.ResourceBarrier(
         2,
-        &[_]d3d12.RESOURCE_BARRIER{
+        &.{
             d3d12.RESOURCE_BARRIER.initUav(gctx.lookupResource(demo.input_buffer).?),
             d3d12.RESOURCE_BARRIER.initUav(gctx.lookupResource(demo.output_buffer).?),
         },
@@ -592,7 +592,7 @@ fn draw(demo: *DemoState) void {
 
     gctx.cmdlist.OMSetRenderTargets(
         1,
-        &[_]d3d12.CPU_DESCRIPTOR_HANDLE{back_buffer.descriptor_handle},
+        &.{back_buffer.descriptor_handle},
         w32.TRUE,
         null,
     );
@@ -611,7 +611,7 @@ fn draw(demo: *DemoState) void {
     gctx.flushResourceBarriers();
 
     gctx.setCurrentPipeline(demo.buffer_to_texture_pso);
-    gctx.setComputeRootDescriptorTable(0, &[_]d3d12.CPU_DESCRIPTOR_HANDLE{
+    gctx.setComputeRootDescriptorTable(0, &.{
         demo.input_buffer_srv,
         demo.image_texture_uav,
     });
@@ -621,14 +621,16 @@ fn draw(demo: *DemoState) void {
     gctx.addTransitionBarrier(demo.image_texture, .{ .PIXEL_SHADER_RESOURCE = true });
     gctx.flushResourceBarriers();
 
-    gctx.cmdlist.RSSetViewports(1, &[_]d3d12.VIEWPORT{.{
-        .TopLeftX = 0.0,
-        .TopLeftY = 0.0,
-        .Width = @as(f32, @floatFromInt(gctx.viewport_width / 2)),
-        .Height = @as(f32, @floatFromInt(gctx.viewport_width / 2)),
-        .MinDepth = 0.0,
-        .MaxDepth = 1.0,
-    }});
+    gctx.cmdlist.RSSetViewports(1, &.{
+        .{
+            .TopLeftX = 0.0,
+            .TopLeftY = 0.0,
+            .Width = @as(f32, @floatFromInt(gctx.viewport_width / 2)),
+            .Height = @as(f32, @floatFromInt(gctx.viewport_width / 2)),
+            .MinDepth = 0.0,
+            .MaxDepth = 1.0,
+        },
+    });
 
     gctx.setCurrentPipeline(demo.draw_texture_pso);
     gctx.cmdlist.IASetPrimitiveTopology(.TRIANGLELIST);
@@ -643,7 +645,7 @@ fn draw(demo: *DemoState) void {
     gctx.flushResourceBarriers();
 
     gctx.setCurrentPipeline(demo.buffer_to_texture_pso);
-    gctx.setComputeRootDescriptorTable(0, &[_]d3d12.CPU_DESCRIPTOR_HANDLE{
+    gctx.setComputeRootDescriptorTable(0, &.{
         demo.output_buffer_srv,
         demo.image_texture_uav,
     });
@@ -652,14 +654,16 @@ fn draw(demo: *DemoState) void {
     gctx.addTransitionBarrier(demo.image_texture, .{ .PIXEL_SHADER_RESOURCE = true });
     gctx.flushResourceBarriers();
 
-    gctx.cmdlist.RSSetViewports(1, &[_]d3d12.VIEWPORT{.{
-        .TopLeftX = @as(f32, @floatFromInt(gctx.viewport_width / 2)),
-        .TopLeftY = 0.0,
-        .Width = @as(f32, @floatFromInt(gctx.viewport_width / 2)),
-        .Height = @as(f32, @floatFromInt(gctx.viewport_width / 2)),
-        .MinDepth = 0.0,
-        .MaxDepth = 1.0,
-    }});
+    gctx.cmdlist.RSSetViewports(1, &.{
+        .{
+            .TopLeftX = @as(f32, @floatFromInt(gctx.viewport_width / 2)),
+            .TopLeftY = 0.0,
+            .Width = @as(f32, @floatFromInt(gctx.viewport_width / 2)),
+            .Height = @as(f32, @floatFromInt(gctx.viewport_width / 2)),
+            .MinDepth = 0.0,
+            .MaxDepth = 1.0,
+        },
+    });
 
     gctx.setCurrentPipeline(demo.draw_texture_pso);
     gctx.cmdlist.IASetPrimitiveTopology(.TRIANGLELIST);

--- a/samples/instanced_pills_wgpu/src/instanced_pills_wgpu.zig
+++ b/samples/instanced_pills_wgpu/src/instanced_pills_wgpu.zig
@@ -268,12 +268,14 @@ const DemoState = struct {
             break :pipline gctx.createRenderPipeline(pipeline_layout, pipeline_descriptor);
         };
 
-        const bind_group = gctx.createBindGroup(bind_group_layout, &[_]zgpu.BindGroupEntryInfo{.{
-            .binding = 0,
-            .buffer_handle = gctx.uniforms.buffer,
-            .offset = 0,
-            .size = @sizeOf(zm.Mat),
-        }});
+        const bind_group = gctx.createBindGroup(bind_group_layout, &.{
+            .{
+                .binding = 0,
+                .buffer_handle = gctx.uniforms.buffer,
+                .offset = 0,
+                .size = @sizeOf(zm.Mat),
+            },
+        });
 
         // Create a depth texture and its 'view'.
         const depth = createDepthTexture(gctx);

--- a/samples/mesh_shader_test/src/mesh_shader_test.zig
+++ b/samples/mesh_shader_test/src/mesh_shader_test.zig
@@ -688,7 +688,7 @@ fn draw(demo: *DemoState) void {
 
     gctx.cmdlist.OMSetRenderTargets(
         1,
-        &[_]d3d12.CPU_DESCRIPTOR_HANDLE{back_buffer.descriptor_handle},
+        &.{back_buffer.descriptor_handle},
         w32.TRUE,
         &demo.depth_texture_dsv,
     );
@@ -709,7 +709,7 @@ fn draw(demo: *DemoState) void {
             gctx.setCurrentPipeline(demo.mesh_shader_pso);
 
             // Bind global buffers that contain data for *all meshes* and *all meshlets*.
-            gctx.setGraphicsRootDescriptorTable(2, &[_]d3d12.CPU_DESCRIPTOR_HANDLE{
+            gctx.setGraphicsRootDescriptorTable(2, &.{
                 demo.vertex_buffer_srv,
                 demo.index_buffer_srv,
                 demo.meshlet_buffer_srv,
@@ -720,7 +720,7 @@ fn draw(demo: *DemoState) void {
             gctx.setCurrentPipeline(demo.vertex_shader_pso);
 
             // Bind global buffers that contain data for *all meshes*.
-            gctx.setGraphicsRootDescriptorTable(2, &[_]d3d12.CPU_DESCRIPTOR_HANDLE{
+            gctx.setGraphicsRootDescriptorTable(2, &.{
                 demo.vertex_buffer_srv,
                 demo.index_buffer_srv,
             });
@@ -728,11 +728,13 @@ fn draw(demo: *DemoState) void {
         .vertex_shader_fixed => {
             gctx.setCurrentPipeline(demo.vertex_shader_fixed_pso);
 
-            gctx.cmdlist.IASetVertexBuffers(0, 1, &[_]d3d12.VERTEX_BUFFER_VIEW{.{
-                .BufferLocation = gctx.lookupResource(demo.vertex_buffer).?.GetGPUVirtualAddress(),
-                .SizeInBytes = @as(u32, @intCast(gctx.getResourceSize(demo.vertex_buffer))),
-                .StrideInBytes = @sizeOf(Vertex),
-            }});
+            gctx.cmdlist.IASetVertexBuffers(0, 1, &.{
+                .{
+                    .BufferLocation = gctx.lookupResource(demo.vertex_buffer).?.GetGPUVirtualAddress(),
+                    .SizeInBytes = @as(u32, @intCast(gctx.getResourceSize(demo.vertex_buffer))),
+                    .StrideInBytes = @sizeOf(Vertex),
+                },
+            });
             gctx.cmdlist.IASetIndexBuffer(&.{
                 .BufferLocation = gctx.lookupResource(demo.index_buffer).?.GetGPUVirtualAddress(),
                 .SizeInBytes = @as(u32, @intCast(gctx.getResourceSize(demo.index_buffer))),
@@ -758,7 +760,7 @@ fn draw(demo: *DemoState) void {
         switch (demo.draw_mode) {
             .mesh_shader => {
                 // Select a mesh to draw by specifying offsets in global buffers.
-                gctx.cmdlist.SetGraphicsRoot32BitConstants(1, 2, &[_]u32{
+                gctx.cmdlist.SetGraphicsRoot32BitConstants(1, 2, &.{
                     mesh.vertex_offset,
                     mesh.meshlet_offset,
                 }, 0);
@@ -766,7 +768,7 @@ fn draw(demo: *DemoState) void {
             },
             .vertex_shader => {
                 // Select a mesh to draw by specifying offsets in global buffers.
-                gctx.cmdlist.SetGraphicsRoot32BitConstants(1, 2, &[_]u32{
+                gctx.cmdlist.SetGraphicsRoot32BitConstants(1, 2, &.{
                     mesh.vertex_offset,
                     mesh.index_offset,
                 }, 0);

--- a/samples/minimal_d3d12/src/minimal_d3d12.zig
+++ b/samples/minimal_d3d12/src/minimal_d3d12.zig
@@ -193,20 +193,24 @@ pub fn main() !void {
         hrPanicOnFail(command_allocator.Reset());
         hrPanicOnFail(dx12.command_list.Reset(command_allocator, null));
 
-        dx12.command_list.RSSetViewports(1, &[_]d3d12.VIEWPORT{.{
-            .TopLeftX = 0.0,
-            .TopLeftY = 0.0,
-            .Width = @floatFromInt(window_rect.right),
-            .Height = @floatFromInt(window_rect.bottom),
-            .MinDepth = 0.0,
-            .MaxDepth = 1.0,
-        }});
-        dx12.command_list.RSSetScissorRects(1, &[_]d3d12.RECT{.{
-            .left = 0,
-            .top = 0,
-            .right = @intCast(window_rect.right),
-            .bottom = @intCast(window_rect.bottom),
-        }});
+        dx12.command_list.RSSetViewports(1, &.{
+            .{
+                .TopLeftX = 0.0,
+                .TopLeftY = 0.0,
+                .Width = @floatFromInt(window_rect.right),
+                .Height = @floatFromInt(window_rect.bottom),
+                .MinDepth = 0.0,
+                .MaxDepth = 1.0,
+            },
+        });
+        dx12.command_list.RSSetScissorRects(1, &.{
+            .{
+                .left = 0,
+                .top = 0,
+                .right = @intCast(window_rect.right),
+                .bottom = @intCast(window_rect.bottom),
+            },
+        });
 
         const back_buffer_index = dx12.swap_chain.GetCurrentBackBufferIndex();
         const back_buffer_descriptor = d3d12.CPU_DESCRIPTOR_HANDLE{
@@ -214,22 +218,24 @@ pub fn main() !void {
                 back_buffer_index * dx12.device.GetDescriptorHandleIncrementSize(.RTV),
         };
 
-        dx12.command_list.ResourceBarrier(1, &[_]d3d12.RESOURCE_BARRIER{.{
-            .Type = .TRANSITION,
-            .Flags = .{},
-            .u = .{
-                .Transition = .{
-                    .pResource = dx12.swap_chain_textures[back_buffer_index],
-                    .Subresource = d3d12.RESOURCE_BARRIER_ALL_SUBRESOURCES,
-                    .StateBefore = d3d12.RESOURCE_STATES.PRESENT,
-                    .StateAfter = .{ .RENDER_TARGET = true },
+        dx12.command_list.ResourceBarrier(1, &.{
+            .{
+                .Type = .TRANSITION,
+                .Flags = .{},
+                .u = .{
+                    .Transition = .{
+                        .pResource = dx12.swap_chain_textures[back_buffer_index],
+                        .Subresource = d3d12.RESOURCE_BARRIER_ALL_SUBRESOURCES,
+                        .StateBefore = d3d12.RESOURCE_STATES.PRESENT,
+                        .StateAfter = .{ .RENDER_TARGET = true },
+                    },
                 },
             },
-        }});
+        });
 
         dx12.command_list.OMSetRenderTargets(
             1,
-            &[_]d3d12.CPU_DESCRIPTOR_HANDLE{back_buffer_descriptor},
+            &.{back_buffer_descriptor},
             w32.TRUE,
             null,
         );
@@ -240,21 +246,23 @@ pub fn main() !void {
         dx12.command_list.SetGraphicsRootSignature(root_signature);
         dx12.command_list.DrawInstanced(3, 1, 0, 0);
 
-        dx12.command_list.ResourceBarrier(1, &[_]d3d12.RESOURCE_BARRIER{.{
-            .Type = .TRANSITION,
-            .Flags = .{},
-            .u = .{
-                .Transition = .{
-                    .pResource = dx12.swap_chain_textures[back_buffer_index],
-                    .Subresource = d3d12.RESOURCE_BARRIER_ALL_SUBRESOURCES,
-                    .StateBefore = .{ .RENDER_TARGET = true },
-                    .StateAfter = d3d12.RESOURCE_STATES.PRESENT,
+        dx12.command_list.ResourceBarrier(1, &.{
+            .{
+                .Type = .TRANSITION,
+                .Flags = .{},
+                .u = .{
+                    .Transition = .{
+                        .pResource = dx12.swap_chain_textures[back_buffer_index],
+                        .Subresource = d3d12.RESOURCE_BARRIER_ALL_SUBRESOURCES,
+                        .StateBefore = .{ .RENDER_TARGET = true },
+                        .StateAfter = d3d12.RESOURCE_STATES.PRESENT,
+                    },
                 },
             },
-        }});
+        });
         hrPanicOnFail(dx12.command_list.Close());
 
-        dx12.command_queue.ExecuteCommandLists(1, &[_]*d3d12.ICommandList{@ptrCast(dx12.command_list)});
+        dx12.command_queue.ExecuteCommandLists(1, &.{@ptrCast(dx12.command_list)});
 
         dx12.present();
 

--- a/samples/minimal_glfw_d3d12/src/minimal_glfw_d3d12.zig
+++ b/samples/minimal_glfw_d3d12/src/minimal_glfw_d3d12.zig
@@ -36,7 +36,7 @@ pub fn main() !void {
 
         var pso_desc = d3d12.GRAPHICS_PIPELINE_STATE_DESC.initDefault();
         pso_desc.DepthStencilState.DepthEnable = w32.FALSE;
-        pso_desc.InputLayout = d3d12.INPUT_LAYOUT_DESC.init(&[_]d3d12.INPUT_ELEMENT_DESC{
+        pso_desc.InputLayout = d3d12.INPUT_LAYOUT_DESC.init(&.{
             d3d12.INPUT_ELEMENT_DESC.init("POSITION", 0, .R32G32_FLOAT, 0, 0, .PER_VERTEX_DATA, 0),
         });
         pso_desc.RTVFormats[0] = .R8G8B8A8_UNORM;
@@ -51,12 +51,12 @@ pub fn main() !void {
     const Vertex = extern struct {
         position: [2]f32,
     };
-    const gpu_vertices = try gctx.uploadVertices(Vertex, &[_]Vertex{
+    const gpu_vertices = try gctx.uploadVertices(Vertex, &.{
         .{ .position = [_]f32{ -0.9, -0.9 } },
         .{ .position = [_]f32{ 0.0, 0.9 } },
         .{ .position = [_]f32{ 0.9, -0.9 } },
     });
-    const gpu_vertex_indices = try gctx.uploadVertexIndices(u16, &[_]u16{ 0, 1, 2 });
+    const gpu_vertex_indices = try gctx.uploadVertexIndices(u16, &.{ 0, 1, 2 });
 
     const Input = extern struct {
         mouse_position: [2]f32,
@@ -96,7 +96,7 @@ pub fn main() !void {
 
             gctx.cmdlist.OMSetRenderTargets(
                 1,
-                &[_]d3d12.CPU_DESCRIPTOR_HANDLE{back_buffer.descriptor_handle},
+                &.{back_buffer.descriptor_handle},
                 w32.TRUE,
                 null,
             );
@@ -121,7 +121,7 @@ pub fn main() !void {
             }
 
             gctx.cmdlist.IASetPrimitiveTopology(.TRIANGLELIST);
-            gctx.cmdlist.IASetVertexBuffers(0, 1, &[_]d3d12.VERTEX_BUFFER_VIEW{gpu_vertices.view});
+            gctx.cmdlist.IASetVertexBuffers(0, 1, &.{gpu_vertices.view});
             gctx.cmdlist.IASetIndexBuffer(&gpu_vertex_indices.view);
             gctx.cmdlist.DrawIndexedInstanced(3, 1, 0, 0, 0);
 

--- a/samples/minimal_zgui_glfw_d3d12/src/minimal_zgui_glfw_d3d12.zig
+++ b/samples/minimal_zgui_glfw_d3d12/src/minimal_zgui_glfw_d3d12.zig
@@ -96,7 +96,7 @@ pub fn main() !void {
 
             gctx.cmdlist.OMSetRenderTargets(
                 1,
-                &[_]d3d12.CPU_DESCRIPTOR_HANDLE{back_buffer.descriptor_handle},
+                &.{back_buffer.descriptor_handle},
                 w32.TRUE,
                 null,
             );

--- a/samples/minimal_zgui_win32_d3d12/src/minimal_zgui_win32_d3d12.zig
+++ b/samples/minimal_zgui_win32_d3d12/src/minimal_zgui_win32_d3d12.zig
@@ -76,7 +76,7 @@ pub fn main() !void {
 
         gctx.cmdlist.OMSetRenderTargets(
             1,
-            &[_]d3d12.CPU_DESCRIPTOR_HANDLE{back_buffer.descriptor_handle},
+            &.{back_buffer.descriptor_handle},
             w32.TRUE,
             null,
         );

--- a/samples/openvr_test/src/openvr_test.zig
+++ b/samples/openvr_test/src/openvr_test.zig
@@ -1280,7 +1280,7 @@ pub fn main() !void {
 
             surface.gctx.cmdlist.OMSetRenderTargets(
                 1,
-                &[_]d3d12.CPU_DESCRIPTOR_HANDLE{back_buffer.descriptor_handle},
+                &.{back_buffer.descriptor_handle},
                 w32.TRUE,
                 null,
             );

--- a/samples/physically_based_rendering_wgpu/src/physically_based_rendering_wgpu.zig
+++ b/samples/physically_based_rendering_wgpu/src/physically_based_rendering_wgpu.zig
@@ -386,7 +386,7 @@ fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
     //
     // Create bind groups.
     //
-    const mesh_bg = gctx.createBindGroup(mesh_bgl, &[_]zgpu.BindGroupEntryInfo{
+    const mesh_bg = gctx.createBindGroup(mesh_bgl, &.{
         .{ .binding = 0, .buffer_handle = gctx.uniforms.buffer, .offset = 0, .size = @sizeOf(MeshUniforms) },
         .{ .binding = 1, .texture_view_handle = mesh_texv[0] },
         .{ .binding = 2, .texture_view_handle = mesh_texv[1] },
@@ -398,7 +398,7 @@ fn create(allocator: std.mem.Allocator, window: *zglfw.Window) !*DemoState {
         .{ .binding = 8, .sampler_handle = aniso_sam },
     });
 
-    const env_bg = gctx.createBindGroup(uniform_texcube_sam_bgl, &[_]zgpu.BindGroupEntryInfo{
+    const env_bg = gctx.createBindGroup(uniform_texcube_sam_bgl, &.{
         .{ .binding = 0, .buffer_handle = gctx.uniforms.buffer, .offset = 0, .size = @sizeOf(zm.Mat) },
         .{ .binding = 1, .texture_view_handle = env_cube_texv },
         .{ .binding = 2, .sampler_handle = trilinear_sam },
@@ -935,7 +935,7 @@ fn precomputeImageLighting(
     // Step 4.
     //
     {
-        const bg = gctx.createBindGroup(demo.texstorage2d_bgl, &[_]zgpu.BindGroupEntryInfo{
+        const bg = gctx.createBindGroup(demo.texstorage2d_bgl, &.{
             .{ .binding = 0, .texture_view_handle = demo.brdf_integration_texv },
         });
         defer gctx.releaseResource(bg);
@@ -987,7 +987,7 @@ fn drawToCubeTexture(
         roughness: f32,
     };
 
-    const bg = gctx.createBindGroup(pipe_bgl, &[_]zgpu.BindGroupEntryInfo{
+    const bg = gctx.createBindGroup(pipe_bgl, &.{
         .{ .binding = 0, .buffer_handle = gctx.uniforms.buffer, .offset = 0, .size = @sizeOf(Uniforms) },
         .{ .binding = 1, .texture_view_handle = source_texv },
         .{ .binding = 2, .sampler_handle = sam },

--- a/samples/procedural_mesh_wgpu/src/procedural_mesh_wgpu.zig
+++ b/samples/procedural_mesh_wgpu/src/procedural_mesh_wgpu.zig
@@ -385,12 +385,14 @@ fn init(allocator: std.mem.Allocator, window: *zglfw.Window) !DemoState {
         break :pipeline gctx.createRenderPipeline(pipeline_layout, pipeline_descriptor);
     };
 
-    const bind_group = gctx.createBindGroup(bind_group_layout, &[_]zgpu.BindGroupEntryInfo{.{
-        .binding = 0,
-        .buffer_handle = gctx.uniforms.buffer,
-        .offset = 0,
-        .size = @max(@sizeOf(FrameUniforms), @sizeOf(DrawUniforms)),
-    }});
+    const bind_group = gctx.createBindGroup(bind_group_layout, &.{
+        .{
+            .binding = 0,
+            .buffer_handle = gctx.uniforms.buffer,
+            .offset = 0,
+            .size = @max(@sizeOf(FrameUniforms), @sizeOf(DrawUniforms)),
+        },
+    });
 
     var drawables = std.ArrayList(Drawable).init(allocator);
     var meshes = std.ArrayList(Mesh).init(allocator);

--- a/samples/rasterization/src/rasterization.zig
+++ b/samples/rasterization/src/rasterization.zig
@@ -557,11 +557,13 @@ fn draw(demo: *DemoState) void {
 
     // Set input assembler (IA) state.
     gctx.cmdlist.IASetPrimitiveTopology(.TRIANGLELIST);
-    gctx.cmdlist.IASetVertexBuffers(0, 1, &[_]d3d12.VERTEX_BUFFER_VIEW{.{
-        .BufferLocation = gctx.lookupResource(demo.vertex_buffer).?.GetGPUVirtualAddress(),
-        .SizeInBytes = demo.mesh_num_vertices * @sizeOf(Pso_Vertex),
-        .StrideInBytes = @sizeOf(Pso_Vertex),
-    }});
+    gctx.cmdlist.IASetVertexBuffers(0, 1, &.{
+        .{
+            .BufferLocation = gctx.lookupResource(demo.vertex_buffer).?.GetGPUVirtualAddress(),
+            .SizeInBytes = demo.mesh_num_vertices * @sizeOf(Pso_Vertex),
+            .StrideInBytes = @sizeOf(Pso_Vertex),
+        },
+    });
     gctx.cmdlist.IASetIndexBuffer(&.{
         .BufferLocation = gctx.lookupResource(demo.index_buffer).?.GetGPUVirtualAddress(),
         .SizeInBytes = demo.mesh_num_indices * @sizeOf(u32),
@@ -601,7 +603,7 @@ fn draw(demo: *DemoState) void {
 
         gctx.cmdlist.OMSetRenderTargets(
             1,
-            &[_]d3d12.CPU_DESCRIPTOR_HANDLE{demo.pixel_texture_rtv},
+            &.{demo.pixel_texture_rtv},
             w32.TRUE,
             &demo.depth_texture_dsv,
         );
@@ -655,7 +657,7 @@ fn draw(demo: *DemoState) void {
             gctx.cmdlist.Dispatch(gctx.viewport_width * gctx.viewport_height / compute_group_size, 1, 1);
             gctx.cmdlist.ResourceBarrier(
                 1,
-                &[_]d3d12.RESOURCE_BARRIER{
+                &.{
                     d3d12.RESOURCE_BARRIER.initUav(gctx.lookupResource(demo.pixel_buffer).?),
                 },
             );
@@ -724,7 +726,7 @@ fn draw(demo: *DemoState) void {
         // Draw pixels to the pixel texture.
         //
         gctx.setCurrentPipeline(demo.draw_pixels_pso);
-        gctx.setComputeRootDescriptorTable(0, &[_]d3d12.CPU_DESCRIPTOR_HANDLE{
+        gctx.setComputeRootDescriptorTable(0, &.{
             demo.pixel_buffer_srv,
             demo.pixel_texture_uav,
         });
@@ -750,7 +752,7 @@ fn draw(demo: *DemoState) void {
     // Set back buffer as a render target (for UI and Direct2D).
     gctx.cmdlist.OMSetRenderTargets(
         1,
-        &[_]d3d12.CPU_DESCRIPTOR_HANDLE{back_buffer.descriptor_handle},
+        &.{back_buffer.descriptor_handle},
         w32.TRUE,
         null,
     );

--- a/samples/simple_openvr/src/simple_openvr.zig
+++ b/samples/simple_openvr/src/simple_openvr.zig
@@ -396,7 +396,7 @@ pub fn main() !void {
                 .u = .{
                     .DescriptorTable = d3d12.ROOT_DESCRIPTOR_TABLE1{
                         .NumDescriptorRanges = 1,
-                        .pDescriptorRanges = &[_]d3d12.DESCRIPTOR_RANGE1{
+                        .pDescriptorRanges = &.{
                             .{
                                 .RangeType = .SRV,
                                 .NumDescriptors = 1,
@@ -661,7 +661,7 @@ pub fn main() !void {
             position: [2]f32,
             tex_coord: [2]f32,
         };
-        const vertices = try gctx.uploadVertices(Vertex, &[_]Vertex{
+        const vertices = try gctx.uploadVertices(Vertex, &.{
             // left eye verts
             .{ .position = [2]f32{ -1, -1 }, .tex_coord = [2]f32{ 0, 1 } },
             .{ .position = [2]f32{ 0, -1 }, .tex_coord = [2]f32{ 1, 1 } },
@@ -675,7 +675,7 @@ pub fn main() !void {
             .{ .position = [2]f32{ 1, 1 }, .tex_coord = [2]f32{ 1, 0 } },
         });
 
-        const indices = &[_]u16{
+        const indices: []const u16 = &.{
             0, 1, 3,
             0, 3, 2,
             4, 5, 7,
@@ -1051,11 +1051,11 @@ pub fn main() !void {
 
                 gctx.cmdlist.OMSetRenderTargets(
                     1,
-                    &[_]d3d12.CPU_DESCRIPTOR_HANDLE{eye_desc.render_target_view_handle},
+                    &.{eye_desc.render_target_view_handle},
                     w32.FALSE,
                     &eye_desc.depth_stencil_view_handle,
                 );
-                gctx.cmdlist.ClearRenderTargetView(eye_desc.render_target_view_handle, &[_]f32{ 0.0, 0.0, 0.0, 1.0 }, 0, null);
+                gctx.cmdlist.ClearRenderTargetView(eye_desc.render_target_view_handle, &.{ 0.0, 0.0, 0.0, 1.0 }, 0, null);
                 gctx.cmdlist.ClearDepthStencilView(eye_desc.depth_stencil_view_handle, .{ .DEPTH = true }, 1.0, 0, 0, null);
 
                 const current_view_projection = zmath.mul(hmd_pose, eye_matrix.get(eye_desc.eye));
@@ -1135,7 +1135,7 @@ pub fn main() !void {
 
             gctx.cmdlist.OMSetRenderTargets(
                 1,
-                &[_]d3d12.CPU_DESCRIPTOR_HANDLE{back_buffer.descriptor_handle},
+                &.{back_buffer.descriptor_handle},
                 w32.TRUE,
                 null,
             );

--- a/samples/textured_quad/src/textured_quad.zig
+++ b/samples/textured_quad/src/textured_quad.zig
@@ -232,7 +232,7 @@ const DemoState = struct {
 
         gctx.cmdlist.OMSetRenderTargets(
             1,
-            &[_]d3d12.CPU_DESCRIPTOR_HANDLE{back_buffer.descriptor_handle},
+            &.{back_buffer.descriptor_handle},
             w32.TRUE,
             null,
         );
@@ -244,11 +244,13 @@ const DemoState = struct {
         );
         gctx.setCurrentPipeline(demo.pipeline);
         gctx.cmdlist.IASetPrimitiveTopology(.TRIANGLESTRIP);
-        gctx.cmdlist.IASetVertexBuffers(0, 1, &[_]d3d12.VERTEX_BUFFER_VIEW{.{
-            .BufferLocation = gctx.lookupResource(demo.vertex_buffer).?.GetGPUVirtualAddress(),
-            .SizeInBytes = num_mipmaps * 4 * @sizeOf(Vertex),
-            .StrideInBytes = @sizeOf(Vertex),
-        }});
+        gctx.cmdlist.IASetVertexBuffers(0, 1, &.{
+            .{
+                .BufferLocation = gctx.lookupResource(demo.vertex_buffer).?.GetGPUVirtualAddress(),
+                .SizeInBytes = num_mipmaps * 4 * @sizeOf(Vertex),
+                .StrideInBytes = @sizeOf(Vertex),
+            },
+        });
         gctx.cmdlist.IASetIndexBuffer(&.{
             .BufferLocation = gctx.lookupResource(demo.index_buffer).?.GetGPUVirtualAddress(),
             .SizeInBytes = 4 * @sizeOf(u32),

--- a/samples/triangle/src/triangle.zig
+++ b/samples/triangle/src/triangle.zig
@@ -138,7 +138,7 @@ pub fn main() !void {
 
         gctx.cmdlist.OMSetRenderTargets(
             1,
-            &[_]d3d12.CPU_DESCRIPTOR_HANDLE{back_buffer.descriptor_handle},
+            &.{back_buffer.descriptor_handle},
             w32.TRUE,
             null,
         );
@@ -150,11 +150,13 @@ pub fn main() !void {
         );
         gctx.setCurrentPipeline(pipeline);
         gctx.cmdlist.IASetPrimitiveTopology(.TRIANGLELIST);
-        gctx.cmdlist.IASetVertexBuffers(0, 1, &[_]d3d12.VERTEX_BUFFER_VIEW{.{
-            .BufferLocation = gctx.lookupResource(vertex_buffer).?.GetGPUVirtualAddress(),
-            .SizeInBytes = 3 * @sizeOf(vm.Vec3),
-            .StrideInBytes = @sizeOf(vm.Vec3),
-        }});
+        gctx.cmdlist.IASetVertexBuffers(0, 1, &.{
+            .{
+                .BufferLocation = gctx.lookupResource(vertex_buffer).?.GetGPUVirtualAddress(),
+                .SizeInBytes = 3 * @sizeOf(vm.Vec3),
+                .StrideInBytes = @sizeOf(vm.Vec3),
+            },
+        });
         gctx.cmdlist.IASetIndexBuffer(&.{
             .BufferLocation = gctx.lookupResource(index_buffer).?.GetGPUVirtualAddress(),
             .SizeInBytes = 3 * @sizeOf(u32),

--- a/samples/triangle_wgpu/src/triangle_wgpu.zig
+++ b/samples/triangle_wgpu/src/triangle_wgpu.zig
@@ -128,7 +128,7 @@ fn init(allocator: std.mem.Allocator, window: *zglfw.Window) !DemoState {
         break :pipeline gctx.createRenderPipeline(pipeline_layout, pipeline_descriptor);
     };
 
-    const bind_group = gctx.createBindGroup(bind_group_layout, &[_]zgpu.BindGroupEntryInfo{
+    const bind_group = gctx.createBindGroup(bind_group_layout, &.{
         .{ .binding = 0, .buffer_handle = gctx.uniforms.buffer, .offset = 0, .size = @sizeOf(zm.Mat) },
     });
 

--- a/samples/vector_graphics_test/src/vector_graphics_test.zig
+++ b/samples/vector_graphics_test/src/vector_graphics_test.zig
@@ -180,11 +180,13 @@ fn init(allocator: std.mem.Allocator) !DemoState {
             const cp2 = d2d1.POINT_2F{ .x = p1.x + 40.0, .y = p1.y - 140.0 };
             ink_points.append(cp1) catch unreachable;
             ink_points.append(cp2) catch unreachable;
-            hrPanicOnFail(ink.AddSegments(&[_]d2d1.INK_BEZIER_SEGMENT{.{
-                .point1 = .{ .x = cp1.x, .y = cp1.y, .radius = 12.5 },
-                .point2 = .{ .x = cp2.x, .y = cp2.y, .radius = 12.5 },
-                .point3 = .{ .x = p1.x, .y = p1.y, .radius = 9.0 },
-            }}, 1));
+            hrPanicOnFail(ink.AddSegments(&.{
+                .{
+                    .point1 = .{ .x = cp1.x, .y = cp1.y, .radius = 12.5 },
+                    .point2 = .{ .x = cp2.x, .y = cp2.y, .radius = 12.5 },
+                    .point3 = .{ .x = p1.x, .y = p1.y, .radius = 9.0 },
+                },
+            }, 1));
             ink_points.append(p1) catch unreachable;
         }
 
@@ -195,11 +197,13 @@ fn init(allocator: std.mem.Allocator) !DemoState {
             const cp2 = d2d1.POINT_2F{ .x = p1.x + 40.0, .y = p1.y - 140.0 };
             ink_points.append(cp1) catch unreachable;
             ink_points.append(cp2) catch unreachable;
-            hrPanicOnFail(ink.AddSegments(&[_]d2d1.INK_BEZIER_SEGMENT{.{
-                .point1 = .{ .x = cp1.x, .y = cp1.y, .radius = 6.25 },
-                .point2 = .{ .x = cp2.x, .y = cp2.y, .radius = 6.25 },
-                .point3 = .{ .x = p1.x, .y = p1.y, .radius = 1.0 },
-            }}, 1));
+            hrPanicOnFail(ink.AddSegments(&.{
+                .{
+                    .point1 = .{ .x = cp1.x, .y = cp1.y, .radius = 6.25 },
+                    .point2 = .{ .x = cp2.x, .y = cp2.y, .radius = 6.25 },
+                    .point3 = .{ .x = p1.x, .y = p1.y, .radius = 1.0 },
+                },
+            }, 1));
             ink_points.append(p1) catch unreachable;
         }
 
@@ -636,7 +640,7 @@ fn draw(demo: *DemoState) void {
 
     gctx.cmdlist.OMSetRenderTargets(
         1,
-        &[_]d3d12.CPU_DESCRIPTOR_HANDLE{back_buffer.descriptor_handle},
+        &.{back_buffer.descriptor_handle},
         w32.TRUE,
         null,
     );


### PR DESCRIPTION
Added helpers:

1. `fn checkFeatureSupport(gctx: *GraphicsContext, comptime feature: d3d12.FEATURE, data: anytype) HResultError!void`
Purpose: Compile time check to ensure correct data is passed in for feature. 
 `HResultError` instead of `HRESULT`.
2. `fn allocRenderTargetView(gctx: *GraphicsContext, handle: ResourceHandle, desc: ?*const d3d12.RENDER_TARGET_VIEW_DESC) d3d12.CPU_DESCRIPTOR_HANDLE`
Purpose: Use `zd3d12.ResourceHandle` instead of `d3d12.IResource`. Allocate required `.RTV` cpu descriptor and returns it.
3. `fn allocDepthStencilView(gctx: *GraphicsContext, handle: ResourceHandle, desc: ?*const d3d12.DEPTH_STENCIL_VIEW_DESC) d3d12.CPU_DESCRIPTOR_HANDLE`
Purpose: Use `zd3d12.ResourceHandle` instead of `d3d12.IResource`. Allocate required `.DSV` cpu descriptor and returns it.
4. `fn createRootSignature(gctx: *GraphicsContext, node_mask: w32.UINT, signature: *d3d.IBlob) HResultError!*d3d12.IRootSignature`
Purpose: Take in signature `IBlob` instead of pointer and size. Return `*IRootSignature` instead of out pointer.  `HResultError` instead of `HRESULT`.
5. `fn writeResource(gctx: *GraphicsContext, comptime T: type, destination: ResourceHandle, source: []const T) HResultError!void`
Purpose: Simplify writing a slice to a resource instead of manually mapping and unmapping a byte array.
6. `fn clearRenderTargetView(gctx: *GraphicsContext, rt_view: d3d12.CPU_DESCRIPTOR_HANDLE, rgba: *const [4]w32.FLOAT, rects: []const w32.RECT) void`
Purpose: `RECT` slice instead of a length and pointer.
7. `fn clearDepthStencilView(gctx: *GraphicsContext, ds_view: d3d12.CPU_DESCRIPTOR_HANDLE, clear_flags: d3d12.CLEAR_FLAGS, depth: w32.FLOAT, stencil: w32.UINT8, rects: []const w32.RECT) void`
Purpose: `RECT` slice instead of a length and pointer.
8. `fn omSetRenderTargets(gctx: *GraphicsContext, render_target_descriptors: []const d3d12.CPU_DESCRIPTOR_HANDLE, single_handle: bool, ds_descriptors: ?*const d3d12.CPU_DESCRIPTOR_HANDLE) void`
Purpose: `CPU_DESCRIPTOR_HANDLE` slice instead of a length and pointer. `bool` instead of `BOOL`.
9. `fn rsSetViewports(gctx: *GraphicsContext, viewports: []const d3d12.VIEWPORT)`
Purpose: `VIEWPORT` slice instead of a length and pointer.
10. `fn rsSetScissorRects(gctx: *GraphicsContext, rects: []const d3d12.RECT)`
Purpose: `RECT` slice instead of a length and pointer.
11. `fn iaSetPrimitiveTopology(gctx: *GraphicsContext, topology: d3d12.PRIMITIVE_TOPOLOGY) void`
Purpose: Passthrough to get rid of last usage of `gctx.cmdlist` in simple_openvr sample
12. `fn iaSetVertexBuffers(gctx: *GraphicsContext, start_slot: w32.UINT, views: []const d3d12.VERTEX_BUFFER_VIEW)`
Purpose: `VERTEX_BUFFER_VIEW` slice instead of a length and pointer.
13. `fn iaSetIndexBuffer(gctx: *GraphicsContext, view: ?*const d3d12.INDEX_BUFFER_VIEW) void`
Purpose: Passthrough to get rid of last usage of `gctx.cmdlist` in simple_openvr sample
14. `fn setGraphicsRootConstantBufferView(gctx: *GraphicsContext, index: w32.UINT, handle: ResourceHandle) void`
Purpose: `zd3d12.ResourceHandle` instead of `d3d12.IResource`.
15. `fn drawInstanced(gctx: *GraphicsContext, vertex_count_per_instance: w32.UINT, instance_count: w32.UINT, start_vertex_location: w32.UINT, start_instance_location: w32.UINT) void`
Purpose: Passthrough to get rid of last usage of `gctx.cmdlist` in simple_openvr sample
16. `fn drawIndexedInstanced(gctx: *GraphicsContext, index_count_per_instance: w32.UINT, instance_count: w32.UINT, start_index_location: w32.UINT, base_vertex_location: w32.INT, start_instance_location: w32.UINT) void`
Purpose: Passthrough to get rid of last usage of `gctx.cmdlist` in simple_openvr sample
17. `fn serializeVersionedRootSignature(root_signature_desc: *const d3d12.VERSIONED_ROOT_SIGNATURE_DESC) HResultError!*d3d.IBlob`
Purpose: Returns `IBlob` instead of out pointer. `HResultError` instead of `HRESULT`.