### PR TITLE
Extracted dxc command from samples to zwin32 compile shaders step

### DIFF
--- a/libs/zwin32/build.zig
+++ b/libs/zwin32/build.zig
@@ -99,7 +99,7 @@ pub fn install_directml(
 
 pub const CompileShaders = struct {
     step: *std.Build.Step,
-    shader_ver: []const u8 = "6_0",
+    shader_ver: []const u8,
 
     pub fn addVsShader(
         self: CompileShaders,
@@ -128,6 +128,22 @@ pub const CompileShaders = struct {
             entry_point,
             output_filename,
             "ps",
+            define,
+        );
+    }
+
+    pub fn addCsShader(
+        self: CompileShaders,
+        input_path: []const u8,
+        entry_point: []const u8,
+        output_filename: []const u8,
+        define: []const u8,
+    ) void {
+        self.addShader(
+            input_path,
+            entry_point,
+            output_filename,
+            "cs",
             define,
         );
     }
@@ -172,8 +188,9 @@ pub const CompileShaders = struct {
     }
 };
 
-pub fn addCompileShaders(b: *std.Build, comptime demo_name: []const u8) CompileShaders {
+pub fn addCompileShaders(b: *std.Build, comptime demo_name: []const u8, options: struct { shader_ver: []const u8 }) CompileShaders {
     return .{
         .step = b.step(demo_name ++ "-dxc", "Build shaders for '" ++ demo_name ++ "' demo"),
+        .shader_ver = options.shader_ver,
     };
 }

--- a/libs/zwin32/build.zig
+++ b/libs/zwin32/build.zig
@@ -204,9 +204,9 @@ pub const CompileShaders = struct {
     }
 };
 
-pub fn addCompileShaders(b: *std.Build, comptime demo_name: []const u8, options: struct { shader_ver: []const u8 }) CompileShaders {
+pub fn addCompileShaders(b: *std.Build, comptime name: []const u8, options: struct { shader_ver: []const u8 }) CompileShaders {
     return .{
-        .step = b.step(demo_name ++ "-dxc", "Build shaders for '" ++ demo_name ++ "' demo"),
+        .step = b.step(name ++ "-dxc", "Build shaders for '" ++ name ++ "'"),
         .shader_ver = options.shader_ver,
     };
 }

--- a/libs/zwin32/build.zig
+++ b/libs/zwin32/build.zig
@@ -148,6 +148,22 @@ pub const CompileShaders = struct {
         );
     }
 
+    pub fn addMsShader(
+        self: CompileShaders,
+        input_path: []const u8,
+        entry_point: []const u8,
+        output_filename: []const u8,
+        define: []const u8,
+    ) void {
+        self.addShader(
+            input_path,
+            entry_point,
+            output_filename,
+            "ms",
+            define,
+        );
+    }
+
     pub fn addShader(
         self: CompileShaders,
         input_path: []const u8,

--- a/libs/zwin32/build.zig
+++ b/libs/zwin32/build.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
@@ -94,4 +95,85 @@ pub fn install_directml(
             "DirectML.Debug.dll",
         ).step,
     );
+}
+
+pub const CompileShaders = struct {
+    step: *std.Build.Step,
+    shader_ver: []const u8 = "6_0",
+
+    pub fn addVsShader(
+        self: CompileShaders,
+        input_path: []const u8,
+        entry_point: []const u8,
+        output_filename: []const u8,
+        define: []const u8,
+    ) void {
+        self.addShader(
+            input_path,
+            entry_point,
+            output_filename,
+            "vs",
+            define,
+        );
+    }
+    pub fn addPsShader(
+        self: CompileShaders,
+        input_path: []const u8,
+        entry_point: []const u8,
+        output_filename: []const u8,
+        define: []const u8,
+    ) void {
+        self.addShader(
+            input_path,
+            entry_point,
+            output_filename,
+            "ps",
+            define,
+        );
+    }
+
+    pub fn addShader(
+        self: CompileShaders,
+        input_path: []const u8,
+        entry_point: []const u8,
+        output_filename: []const u8,
+        profile: []const u8,
+        define: []const u8,
+    ) void {
+        const b = self.step.owner;
+
+        const zwin32_path = comptime std.fs.path.dirname(@src().file) orelse ".";
+        const dxc_path = switch (builtin.target.os.tag) {
+            .windows => zwin32_path ++ "/bin/x64/dxc.exe",
+            .linux => zwin32_path ++ "/bin/x64/dxc",
+            else => @panic("Unsupported target"),
+        };
+
+        const dxc_command = [9][]const u8{
+            dxc_path,
+            input_path,
+            b.fmt("/E {s}", .{entry_point}),
+            b.fmt("/Fo {s}", .{output_filename}),
+            b.fmt("/T {s}_{s}", .{ profile, self.shader_ver }),
+            if (define.len == 0) "" else b.fmt("/D {s}", .{define}),
+            "/WX",
+            "/Ges",
+            "/O3",
+        };
+
+        const cmd_step = b.addSystemCommand(&dxc_command);
+        if (builtin.target.os.tag == .linux) {
+            cmd_step.setEnvironmentVariable(
+                "LD_LIBRARY_PATH",
+                zwin32_path ++ "/bin/x64",
+            );
+        }
+        self.step.dependOn(&cmd_step.step);
+    }
+};
+
+pub fn addCompileShaders(b: *std.Build, comptime demo_name: []const u8) CompileShaders {
+    return .{
+        .step = b.step(demo_name ++ "-dxc", "Build shaders for '" ++ demo_name ++ "' demo"),
+    };
 }

--- a/samples/audio_experiments/build.zig
+++ b/samples/audio_experiments/build.zig
@@ -69,7 +69,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
         const shaders_path = b.pathJoin(&.{ root_path, content_path, "shaders" });
 
         const common_hlsl_path = b.pathJoin(&.{ root_path, "samples", "common/src/hlsl/common.hlsl" });
-        compile_shaders.adVsdShader(common_hlsl_path, "vsImGui", b.pathJoin(&.{ shaders_path, "imgui.vs.cso" }), "PSO__IMGUI");
+        compile_shaders.addVsShader(common_hlsl_path, "vsImGui", b.pathJoin(&.{ shaders_path, "imgui.vs.cso" }), "PSO__IMGUI");
         compile_shaders.addPsShader(common_hlsl_path, "psImGui", b.pathJoin(&.{ shaders_path, "imgui.ps.cso" }), "PSO__IMGUI");
 
         const hlsl_path = b.pathJoin(&.{ root_path, src_path, demo_name ++ ".hlsl" });

--- a/samples/audio_experiments/build.zig
+++ b/samples/audio_experiments/build.zig
@@ -64,7 +64,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     });
 
     if (builtin.os.tag == .windows or builtin.os.tag == .linux) {
-        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name, .{ .shader_ver = "6_0" });
+        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name, .{ .shader_ver = "6_6" });
         const root_path = pathResolve(b, &.{ @src().file, "..", "..", ".." });
         const shaders_path = b.pathJoin(&.{ root_path, content_path, "shaders" });
 

--- a/samples/audio_experiments/build.zig
+++ b/samples/audio_experiments/build.zig
@@ -2,12 +2,20 @@ const builtin = @import("builtin");
 const std = @import("std");
 
 const Options = @import("../../build.zig").Options;
-const content_dir = "audio_experiments_content/";
+const demo_name = "audio_experiments";
+const content_dir = demo_name ++ "_content/";
+
+// in future zig version e342433
+pub fn pathResolve(b: *std.Build, paths: []const []const u8) []u8 {
+    return std.fs.path.resolve(b.allocator, paths) catch @panic("OOM");
+}
 
 pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
+    const cwd_path = b.pathJoin(&.{ "samples", demo_name });
+    const src_path = b.pathJoin(&.{ cwd_path, "src" });
     const exe = b.addExecutable(.{
-        .name = "audio_experiments",
-        .root_source_file = .{ .path = thisDir() ++ "/src/audio_experiments.zig" },
+        .name = demo_name,
+        .root_source_file = b.path(b.pathJoin(&.{ src_path, demo_name ++ ".zig" })),
         .target = options.target,
         .optimize = options.optimize,
     });
@@ -48,16 +56,27 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
+    const content_path = b.pathJoin(&.{ cwd_path, content_dir });
     const install_content_step = b.addInstallDirectory(.{
-        .source_dir = .{ .path = thisDir() ++ "/" ++ content_dir },
+        .source_dir = b.path(content_path),
         .install_dir = .{ .custom = "" },
-        .install_subdir = "bin/" ++ content_dir,
+        .install_subdir = b.pathJoin(&.{ "bin", content_dir }),
     });
 
     if (builtin.os.tag == .windows or builtin.os.tag == .linux) {
-        const dxc_step = buildShaders(b);
-        exe.step.dependOn(dxc_step);
-        install_content_step.step.dependOn(dxc_step);
+        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name);
+        const root_path = pathResolve(b, &.{ @src().file, "..", "..", ".." });
+        const shaders_path = b.pathJoin(&.{ root_path, content_path, "shaders" });
+
+        const common_hlsl_path = b.pathJoin(&.{ root_path, "samples", "common/src/hlsl/common.hlsl" });
+        compile_shaders.adVsdShader(common_hlsl_path, "vsImGui", b.pathJoin(&.{ shaders_path, "imgui.vs.cso" }), "PSO__IMGUI");
+        compile_shaders.addPsShader(common_hlsl_path, "psImGui", b.pathJoin(&.{ shaders_path, "imgui.ps.cso" }), "PSO__IMGUI");
+
+        const hlsl_path = b.pathJoin(&.{ root_path, src_path, demo_name ++ ".hlsl" });
+        compile_shaders.addVsShader(hlsl_path, "vsMain", b.pathJoin(&.{ shaders_path, demo_name ++ ".vs.cso" }), "");
+        compile_shaders.addPsShader(hlsl_path, "psMain", b.pathJoin(&.{ shaders_path, demo_name ++ ".ps.cso" }), "");
+
+        install_content_step.step.dependOn(compile_shaders.step);
     }
 
     exe.step.dependOn(&install_content_step.step);
@@ -71,72 +90,4 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     @import("zwin32").install_d3d12(&exe.step, .bin, "libs/zwin32") catch unreachable;
 
     return exe;
-}
-
-fn buildShaders(b: *std.Build) *std.Build.Step {
-    const dxc_step = b.step("audio_experiments-dxc", "Build shaders for 'audio experiments' demo");
-
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "../common/src/hlsl/common.hlsl",
-        "vsImGui",
-        "imgui.vs.cso",
-        "vs",
-        "PSO__IMGUI",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "../common/src/hlsl/common.hlsl",
-        "psImGui",
-        "imgui.ps.cso",
-        "ps",
-        "PSO__IMGUI",
-    );
-    makeDxcCmd(b, dxc_step, "src/audio_experiments.hlsl", "vsMain", "lines.vs.cso", "vs", "");
-    makeDxcCmd(b, dxc_step, "src/audio_experiments.hlsl", "psMain", "lines.ps.cso", "ps", "");
-
-    return dxc_step;
-}
-
-fn makeDxcCmd(
-    b: *std.Build,
-    dxc_step: *std.Build.Step,
-    comptime input_path: []const u8,
-    comptime entry_point: []const u8,
-    comptime output_filename: []const u8,
-    comptime profile: []const u8,
-    comptime define: []const u8,
-) void {
-    const shader_ver = "6_6";
-    const shader_dir = thisDir() ++ "/" ++ content_dir ++ "shaders/";
-
-    const dxc_path = switch (builtin.target.os.tag) {
-        .windows => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc.exe",
-        .linux => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc",
-        else => @panic("Unsupported target"),
-    };
-
-    const dxc_command = [9][]const u8{
-        dxc_path,
-        thisDir() ++ "/" ++ input_path,
-        "/E " ++ entry_point,
-        "/Fo " ++ shader_dir ++ output_filename,
-        "/T " ++ profile ++ "_" ++ shader_ver,
-        if (define.len == 0) "" else "/D " ++ define,
-        "/WX",
-        "/Ges",
-        "/O3",
-    };
-
-    const cmd_step = b.addSystemCommand(&dxc_command);
-    if (builtin.target.os.tag == .linux) {
-        cmd_step.setEnvironmentVariable("LD_LIBRARY_PATH", thisDir() ++ "/../../libs/zwin32/bin/x64");
-    }
-    dxc_step.dependOn(&cmd_step.step);
-}
-
-inline fn thisDir() []const u8 {
-    return comptime std.fs.path.dirname(@src().file) orelse ".";
 }

--- a/samples/audio_experiments/build.zig
+++ b/samples/audio_experiments/build.zig
@@ -64,7 +64,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     });
 
     if (builtin.os.tag == .windows or builtin.os.tag == .linux) {
-        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name);
+        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name, .{ .shader_ver = "6_0" });
         const root_path = pathResolve(b, &.{ @src().file, "..", "..", ".." });
         const shaders_path = b.pathJoin(&.{ root_path, content_path, "shaders" });
 

--- a/samples/audio_experiments/src/audio_experiments.zig
+++ b/samples/audio_experiments/src/audio_experiments.zig
@@ -211,8 +211,8 @@ fn init(allocator: std.mem.Allocator) !DemoState {
         pso_desc.NumRenderTargets = 1;
         pso_desc.DSVFormat = .D32_FLOAT;
         pso_desc.PrimitiveTopologyType = .LINE;
-        pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/lines.vs.cso", null));
-        pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/lines.ps.cso", null));
+        pso_desc.VS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/audio_experiments.vs.cso", null));
+        pso_desc.PS = d3d12.SHADER_BYTECODE.init(try common.readContentDirFileAlloc(arena_allocator, content_dir, "shaders/audio_experiments.ps.cso", null));
 
         break :blk gctx.createGraphicsShaderPipeline(&pso_desc);
     };

--- a/samples/audio_playback_test/build.zig
+++ b/samples/audio_playback_test/build.zig
@@ -2,12 +2,21 @@ const builtin = @import("builtin");
 const std = @import("std");
 
 const Options = @import("../../build.zig").Options;
-const content_dir = "audio_playback_test_content/";
+
+const demo_name = "audio_playback_test";
+const content_dir = demo_name ++ "_content/";
+
+// in future zig version e342433
+pub fn pathResolve(b: *std.Build, paths: []const []const u8) []u8 {
+    return std.fs.path.resolve(b.allocator, paths) catch @panic("OOM");
+}
 
 pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
+    const cwd_path = b.pathJoin(&.{ "samples", demo_name });
+    const src_path = b.pathJoin(&.{ cwd_path, "src" });
     const exe = b.addExecutable(.{
-        .name = "audio_playback_test",
-        .root_source_file = .{ .path = thisDir() ++ "/src/audio_playback_test.zig" },
+        .name = demo_name,
+        .root_source_file = b.path(b.pathJoin(&.{ src_path, demo_name ++ ".zig" })),
         .target = options.target,
         .optimize = options.optimize,
     });
@@ -37,15 +46,28 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
+    const content_path = b.pathJoin(&.{ cwd_path, content_dir });
     const install_content_step = b.addInstallDirectory(.{
-        .source_dir = .{ .path = thisDir() ++ "/" ++ content_dir },
+        .source_dir = b.path(content_path),
         .install_dir = .{ .custom = "" },
-        .install_subdir = "bin/" ++ content_dir,
+        .install_subdir = b.pathJoin(&.{ "bin", content_dir }),
     });
     if (builtin.os.tag == .windows or builtin.os.tag == .linux) {
-        const dxc_step = buildShaders(b);
-        exe.step.dependOn(dxc_step);
-        install_content_step.step.dependOn(dxc_step);
+        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name);
+        const root_path = pathResolve(b, &.{ @src().file, "..", "..", ".." });
+        const shaders_path = b.pathJoin(&.{ root_path, content_path, "shaders" });
+
+        const common_hlsl_path = b.pathJoin(&.{ root_path, "samples", "common/src/hlsl/common.hlsl" });
+        compile_shaders.addVsShader(common_hlsl_path, "vsImGui", b.pathJoin(&.{ shaders_path, "imgui.vs.cso" }), "PSO__IMGUI");
+        compile_shaders.addPsShader(common_hlsl_path, "psImGui", b.pathJoin(&.{ shaders_path, "imgui.ps.cso" }), "PSO__IMGUI");
+
+        const hlsl_path = b.pathJoin(&.{ root_path, src_path, demo_name ++ ".hlsl" });
+        compile_shaders.addVsShader(hlsl_path, "vsLines", b.pathJoin(&.{ shaders_path, "lines.vs.cso" }), "PSO__LINES");
+        compile_shaders.addPsShader(hlsl_path, "psLines", b.pathJoin(&.{ shaders_path, "lines.ps.cso" }), "PSO__LINES");
+        compile_shaders.addVsShader(hlsl_path, "vsImage", b.pathJoin(&.{ shaders_path, "image.vs.cso" }), "PSO__IMAGE");
+        compile_shaders.addPsShader(hlsl_path, "psImage", b.pathJoin(&.{ shaders_path, "image.ps.cso" }), "PSO__IMAGE");
+
+        install_content_step.step.dependOn(compile_shaders.step);
     }
     exe.step.dependOn(&install_content_step.step);
 
@@ -58,106 +80,4 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     @import("zwin32").install_d3d12(&exe.step, .bin, "libs/zwin32") catch unreachable;
 
     return exe;
-}
-
-fn buildShaders(b: *std.Build) *std.Build.Step {
-    const dxc_step = b.step("audio_playback_test-dxc", "Build shaders for 'audio playback test' demo");
-
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "../common/src/hlsl/common.hlsl",
-        "vsImGui",
-        "imgui.vs.cso",
-        "vs",
-        "PSO__IMGUI",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "../common/src/hlsl/common.hlsl",
-        "psImGui",
-        "imgui.ps.cso",
-        "ps",
-        "PSO__IMGUI",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/audio_playback_test.hlsl",
-        "vsLines",
-        "lines.vs.cso",
-        "vs",
-        "PSO__LINES",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/audio_playback_test.hlsl",
-        "psLines",
-        "lines.ps.cso",
-        "ps",
-        "PSO__LINES",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/audio_playback_test.hlsl",
-        "vsImage",
-        "image.vs.cso",
-        "vs",
-        "PSO__IMAGE",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/audio_playback_test.hlsl",
-        "psImage",
-        "image.ps.cso",
-        "ps",
-        "PSO__IMAGE",
-    );
-
-    return dxc_step;
-}
-
-fn makeDxcCmd(
-    b: *std.Build,
-    dxc_step: *std.Build.Step,
-    comptime input_path: []const u8,
-    comptime entry_point: []const u8,
-    comptime output_filename: []const u8,
-    comptime profile: []const u8,
-    comptime define: []const u8,
-) void {
-    const shader_ver = "6_6";
-    const shader_dir = thisDir() ++ "/" ++ content_dir ++ "shaders/";
-
-    const dxc_path = switch (builtin.target.os.tag) {
-        .windows => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc.exe",
-        .linux => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc",
-        else => @panic("Unsupported target"),
-    };
-
-    const dxc_command = [9][]const u8{
-        dxc_path,
-        thisDir() ++ "/" ++ input_path,
-        "/E " ++ entry_point,
-        "/Fo " ++ shader_dir ++ output_filename,
-        "/T " ++ profile ++ "_" ++ shader_ver,
-        if (define.len == 0) "" else "/D " ++ define,
-        "/WX",
-        "/Ges",
-        "/O3",
-    };
-
-    const cmd_step = b.addSystemCommand(&dxc_command);
-    if (builtin.target.os.tag == .linux) {
-        cmd_step.setEnvironmentVariable("LD_LIBRARY_PATH", thisDir() ++ "/../../libs/zwin32/bin/x64");
-    }
-    dxc_step.dependOn(&cmd_step.step);
-}
-
-inline fn thisDir() []const u8 {
-    return comptime std.fs.path.dirname(@src().file) orelse ".";
 }

--- a/samples/audio_playback_test/build.zig
+++ b/samples/audio_playback_test/build.zig
@@ -53,7 +53,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
         .install_subdir = b.pathJoin(&.{ "bin", content_dir }),
     });
     if (builtin.os.tag == .windows or builtin.os.tag == .linux) {
-        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name);
+        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name, .{ .shader_ver = "6_6" });
         const root_path = pathResolve(b, &.{ @src().file, "..", "..", ".." });
         const shaders_path = b.pathJoin(&.{ root_path, content_path, "shaders" });
 

--- a/samples/bindless/build.zig
+++ b/samples/bindless/build.zig
@@ -2,12 +2,21 @@ const builtin = @import("builtin");
 const std = @import("std");
 
 const Options = @import("../../build.zig").Options;
-const content_dir = "bindless_content/";
+
+const demo_name = "bindless";
+const content_dir = demo_name ++ "_content/";
+
+// in future zig version e342433
+pub fn pathResolve(b: *std.Build, paths: []const []const u8) []u8 {
+    return std.fs.path.resolve(b.allocator, paths) catch @panic("OOM");
+}
 
 pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
+    const cwd_path = b.pathJoin(&.{ "samples", demo_name });
+    const src_path = b.pathJoin(&.{ cwd_path, "src" });
     const exe = b.addExecutable(.{
-        .name = "bindless",
-        .root_source_file = .{ .path = thisDir() ++ "/src/bindless.zig" },
+        .name = demo_name,
+        .root_source_file = b.path(b.pathJoin(&.{ src_path, demo_name ++ ".zig" })),
         .target = options.target,
         .optimize = options.optimize,
     });
@@ -49,15 +58,36 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
+    const content_path = b.pathJoin(&.{ cwd_path, content_dir });
     const install_content_step = b.addInstallDirectory(.{
-        .source_dir = .{ .path = thisDir() ++ "/" ++ content_dir },
+        .source_dir = b.path(content_path),
         .install_dir = .{ .custom = "" },
-        .install_subdir = "bin/" ++ content_dir,
+        .install_subdir = b.pathJoin(&.{ "bin", content_dir }),
     });
     if (builtin.os.tag == .windows or builtin.os.tag == .linux) {
-        const dxc_step = buildShaders(b);
-        exe.step.dependOn(dxc_step);
-        install_content_step.step.dependOn(dxc_step);
+        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name, .{ .shader_ver = "6_6" });
+        const root_path = pathResolve(b, &.{ @src().file, "..", "..", ".." });
+        const shaders_path = b.pathJoin(&.{ root_path, content_path, "shaders" });
+
+        const common_hlsl_path = b.pathJoin(&.{ root_path, "samples", "common/src/hlsl/common.hlsl" });
+        compile_shaders.addVsShader(common_hlsl_path, "vsImGui", b.pathJoin(&.{ shaders_path, "imgui.vs.cso" }), "PSO__IMGUI");
+        compile_shaders.addPsShader(common_hlsl_path, "psImGui", b.pathJoin(&.{ shaders_path, "imgui.ps.cso" }), "PSO__IMGUI");
+        compile_shaders.addCsShader(common_hlsl_path, "csGenerateMipmaps", b.pathJoin(&.{ shaders_path, "generate_mipmaps.ps.cso" }), "PSO__GENERATE_MIPMAPS");
+
+        const hlsl_path = b.pathJoin(&.{ root_path, src_path, demo_name ++ ".hlsl" });
+        compile_shaders.addVsShader(hlsl_path, "vsMeshPbr", b.pathJoin(&.{ shaders_path, "mesh_pbr.vs.cso" }), "PSO__MESH_PBR");
+        compile_shaders.addPsShader(hlsl_path, "psMeshPbr", b.pathJoin(&.{ shaders_path, "mesh_pbr.ps.cso" }), "PSO__MESH_PBR");
+        compile_shaders.addVsShader(hlsl_path, "vsGenerateEnvTexture", b.pathJoin(&.{ shaders_path, "generate_env_texture.vs.cso" }), "PSO__GENERATE_ENV_TEXTURE");
+        compile_shaders.addPsShader(hlsl_path, "psGenerateEnvTexture", b.pathJoin(&.{ shaders_path, "generate_env_texture.ps.cso" }), "PSO__GENERATE_ENV_TEXTURE");
+        compile_shaders.addVsShader(hlsl_path, "vsSampleEnvTexture", b.pathJoin(&.{ shaders_path, "sample_env_texture.vs.cso" }), "PSO__SAMPLE_ENV_TEXTURE");
+        compile_shaders.addPsShader(hlsl_path, "psSampleEnvTexture", b.pathJoin(&.{ shaders_path, "sample_env_texture.ps.cso" }), "PSO__SAMPLE_ENV_TEXTURE");
+        compile_shaders.addVsShader(hlsl_path, "vsGenerateIrradianceTexture", b.pathJoin(&.{ shaders_path, "generate_irradiance_texture.vs.cso" }), "PSO__GENERATE_IRRADIANCE_TEXTURE");
+        compile_shaders.addPsShader(hlsl_path, "psGenerateIrradianceTexture", b.pathJoin(&.{ shaders_path, "generate_irradiance_texture.ps.cso" }), "PSO__GENERATE_IRRADIANCE_TEXTURE");
+        compile_shaders.addVsShader(hlsl_path, "vsGeneratePrefilteredEnvTexture", b.pathJoin(&.{ shaders_path, "generate_prefiltered_env_texture.vs.cso" }), "PSO__GENERATE_PREFILTERED_ENV_TEXTURE");
+        compile_shaders.addPsShader(hlsl_path, "psGeneratePrefilteredEnvTexture", b.pathJoin(&.{ shaders_path, "generate_prefiltered_env_texture.ps.cso" }), "PSO__GENERATE_PREFILTERED_ENV_TEXTURE");
+        compile_shaders.addCsShader(hlsl_path, "csGenerateBrdfIntegrationTexture", b.pathJoin(&.{ shaders_path, "generate_brdf_integration_texture.cs.cso" }), "PSO__GENERATE_BRDF_INTEGRATION_TEXTURE");
+
+        install_content_step.step.dependOn(compile_shaders.step);
     }
     exe.step.dependOn(&install_content_step.step);
 
@@ -69,181 +99,4 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     @import("zwin32").install_d3d12(&exe.step, .bin, "libs/zwin32") catch unreachable;
 
     return exe;
-}
-
-fn buildShaders(b: *std.Build) *std.Build.Step {
-    const dxc_step = b.step("bindless-dxc", "Build shaders for 'bindless' demo");
-
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "../common/src/hlsl/common.hlsl",
-        "vsImGui",
-        "imgui.vs.cso",
-        "vs",
-        "PSO__IMGUI",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "../common/src/hlsl/common.hlsl",
-        "psImGui",
-        "imgui.ps.cso",
-        "ps",
-        "PSO__IMGUI",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "../common/src/hlsl/common.hlsl",
-        "csGenerateMipmaps",
-        "generate_mipmaps.cs.cso",
-        "cs",
-        "PSO__GENERATE_MIPMAPS",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/bindless.hlsl",
-        "vsMeshPbr",
-        "mesh_pbr.vs.cso",
-        "vs",
-        "PSO__MESH_PBR",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/bindless.hlsl",
-        "psMeshPbr",
-        "mesh_pbr.ps.cso",
-        "ps",
-        "PSO__MESH_PBR",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/bindless.hlsl",
-        "vsGenerateEnvTexture",
-        "generate_env_texture.vs.cso",
-        "vs",
-        "PSO__GENERATE_ENV_TEXTURE",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/bindless.hlsl",
-        "psGenerateEnvTexture",
-        "generate_env_texture.ps.cso",
-        "ps",
-        "PSO__GENERATE_ENV_TEXTURE",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/bindless.hlsl",
-        "vsSampleEnvTexture",
-        "sample_env_texture.vs.cso",
-        "vs",
-        "PSO__SAMPLE_ENV_TEXTURE",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/bindless.hlsl",
-        "psSampleEnvTexture",
-        "sample_env_texture.ps.cso",
-        "ps",
-        "PSO__SAMPLE_ENV_TEXTURE",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/bindless.hlsl",
-        "vsGenerateIrradianceTexture",
-        "generate_irradiance_texture.vs.cso",
-        "vs",
-        "PSO__GENERATE_IRRADIANCE_TEXTURE",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/bindless.hlsl",
-        "psGenerateIrradianceTexture",
-        "generate_irradiance_texture.ps.cso",
-        "ps",
-        "PSO__GENERATE_IRRADIANCE_TEXTURE",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/bindless.hlsl",
-        "vsGeneratePrefilteredEnvTexture",
-        "generate_prefiltered_env_texture.vs.cso",
-        "vs",
-        "PSO__GENERATE_PREFILTERED_ENV_TEXTURE",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/bindless.hlsl",
-        "psGeneratePrefilteredEnvTexture",
-        "generate_prefiltered_env_texture.ps.cso",
-        "ps",
-        "PSO__GENERATE_PREFILTERED_ENV_TEXTURE",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/bindless.hlsl",
-        "csGenerateBrdfIntegrationTexture",
-        "generate_brdf_integration_texture.cs.cso",
-        "cs",
-        "PSO__GENERATE_BRDF_INTEGRATION_TEXTURE",
-    );
-
-    return dxc_step;
-}
-
-fn makeDxcCmd(
-    b: *std.Build,
-    dxc_step: *std.Build.Step,
-    comptime input_path: []const u8,
-    comptime entry_point: []const u8,
-    comptime output_filename: []const u8,
-    comptime profile: []const u8,
-    comptime define: []const u8,
-) void {
-    const shader_ver = "6_6";
-    const shader_dir = thisDir() ++ "/" ++ content_dir ++ "shaders/";
-
-    const dxc_path = switch (builtin.target.os.tag) {
-        .windows => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc.exe",
-        .linux => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc",
-        else => @panic("Unsupported target"),
-    };
-
-    const dxc_command = [9][]const u8{
-        dxc_path,
-        thisDir() ++ "/" ++ input_path,
-        "/E " ++ entry_point,
-        "/Fo " ++ shader_dir ++ output_filename,
-        "/T " ++ profile ++ "_" ++ shader_ver,
-        if (define.len == 0) "" else "/D " ++ define,
-        "/WX",
-        "/Ges",
-        "/O3",
-    };
-
-    const cmd_step = b.addSystemCommand(&dxc_command);
-    if (builtin.target.os.tag == .linux) {
-        cmd_step.setEnvironmentVariable(
-            "LD_LIBRARY_PATH",
-            thisDir() ++ "/../../libs/zwin32/bin/x64",
-        );
-    }
-    dxc_step.dependOn(&cmd_step.step);
-}
-
-inline fn thisDir() []const u8 {
-    return comptime std.fs.path.dirname(@src().file) orelse ".";
 }

--- a/samples/directml_convolution_test/build.zig
+++ b/samples/directml_convolution_test/build.zig
@@ -2,12 +2,20 @@ const builtin = @import("builtin");
 const std = @import("std");
 
 const Options = @import("../../build.zig").Options;
-const content_dir = "directml_convolution_test_content/";
 
+const demo_name = "directml_convolution_test";
+const content_dir = demo_name ++ "_content/";
+
+// in future zig version e342433
+pub fn pathResolve(b: *std.Build, paths: []const []const u8) []u8 {
+    return std.fs.path.resolve(b.allocator, paths) catch @panic("OOM");
+}
 pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
+    const cwd_path = b.pathJoin(&.{ "samples", demo_name });
+    const src_path = b.pathJoin(&.{ cwd_path, "src" });
     const exe = b.addExecutable(.{
-        .name = "directml_convolution_test",
-        .root_source_file = .{ .path = thisDir() ++ "/src/directml_convolution_test.zig" },
+        .name = demo_name,
+        .root_source_file = b.path(b.pathJoin(&.{ src_path, demo_name ++ ".zig" })),
         .target = options.target,
         .optimize = options.optimize,
     });
@@ -38,15 +46,28 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     exe_options.addOption([]const u8, "content_dir", content_dir);
     exe_options.addOption(bool, "zd3d12_enable_debug_layer", options.zd3d12_enable_debug_layer);
 
+    const content_path = b.pathJoin(&.{ cwd_path, content_dir });
     const install_content_step = b.addInstallDirectory(.{
-        .source_dir = .{ .path = thisDir() ++ "/" ++ content_dir },
+        .source_dir = b.path(content_path),
         .install_dir = .{ .custom = "" },
-        .install_subdir = "bin/" ++ content_dir,
+        .install_subdir = b.pathJoin(&.{ "bin", content_dir }),
     });
     if (builtin.os.tag == .windows or builtin.os.tag == .linux) {
-        const dxc_step = buildShaders(b);
-        exe.step.dependOn(dxc_step);
-        install_content_step.step.dependOn(dxc_step);
+        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name, .{ .shader_ver = "6_0" });
+        const root_path = pathResolve(b, &.{ @src().file, "..", "..", ".." });
+        const shaders_path = b.pathJoin(&.{ root_path, content_path, "shaders" });
+
+        const common_hlsl_path = b.pathJoin(&.{ root_path, "samples", "common/src/hlsl/common.hlsl" });
+        compile_shaders.addVsShader(common_hlsl_path, "vsImGui", b.pathJoin(&.{ shaders_path, "imgui.vs.cso" }), "PSO__IMGUI");
+        compile_shaders.addPsShader(common_hlsl_path, "psImGui", b.pathJoin(&.{ shaders_path, "imgui.ps.cso" }), "PSO__IMGUI");
+
+        const hlsl_path = b.pathJoin(&.{ root_path, src_path, demo_name ++ ".hlsl" });
+        compile_shaders.addVsShader(hlsl_path, "vsDrawTexture", b.pathJoin(&.{ shaders_path, "draw_texture.vs.cso" }), "PSO__DRAW_TEXTURE");
+        compile_shaders.addPsShader(hlsl_path, "psDrawTexture", b.pathJoin(&.{ shaders_path, "draw_texture.ps.cso" }), "PSO__DRAW_TEXTURE");
+        compile_shaders.addCsShader(hlsl_path, "csTextureToBuffer", b.pathJoin(&.{ shaders_path, "texture_to_buffer.cs.cso" }), "PSO__TEXTURE_TO_BUFFER");
+        compile_shaders.addCsShader(hlsl_path, "csBufferToTexture", b.pathJoin(&.{ shaders_path, "buffer_to_texture.cs.cso" }), "PSO__BUFFER_TO_TEXTURE");
+
+        install_content_step.step.dependOn(compile_shaders.step);
     }
     exe.step.dependOn(&install_content_step.step);
 
@@ -58,112 +79,4 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     @import("zwin32").install_directml(&exe.step, .bin, "libs/zwin32") catch unreachable;
 
     return exe;
-}
-
-fn buildShaders(b: *std.Build) *std.Build.Step {
-    const dxc_step = b.step(
-        "directml_convolution_test-dxc",
-        "Build shaders for 'directml convolution test' demo",
-    );
-
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "../common/src/hlsl/common.hlsl",
-        "vsImGui",
-        "imgui.vs.cso",
-        "vs",
-        "PSO__IMGUI",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "../common/src/hlsl/common.hlsl",
-        "psImGui",
-        "imgui.ps.cso",
-        "ps",
-        "PSO__IMGUI",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/directml_convolution_test.hlsl",
-        "vsDrawTexture",
-        "draw_texture.vs.cso",
-        "vs",
-        "PSO__DRAW_TEXTURE",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/directml_convolution_test.hlsl",
-        "psDrawTexture",
-        "draw_texture.ps.cso",
-        "ps",
-        "PSO__DRAW_TEXTURE",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/directml_convolution_test.hlsl",
-        "csTextureToBuffer",
-        "texture_to_buffer.cs.cso",
-        "cs",
-        "PSO__TEXTURE_TO_BUFFER",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/directml_convolution_test.hlsl",
-        "csBufferToTexture",
-        "buffer_to_texture.cs.cso",
-        "cs",
-        "PSO__BUFFER_TO_TEXTURE",
-    );
-
-    return dxc_step;
-}
-
-fn makeDxcCmd(
-    b: *std.Build,
-    dxc_step: *std.Build.Step,
-    comptime input_path: []const u8,
-    comptime entry_point: []const u8,
-    comptime output_filename: []const u8,
-    comptime profile: []const u8,
-    comptime define: []const u8,
-) void {
-    const shader_ver = "6_6";
-    const shader_dir = thisDir() ++ "/" ++ content_dir ++ "shaders/";
-
-    const dxc_path = switch (builtin.target.os.tag) {
-        .windows => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc.exe",
-        .linux => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc",
-        else => @panic("Unsupported target"),
-    };
-
-    const dxc_command = [9][]const u8{
-        dxc_path,
-        thisDir() ++ "/" ++ input_path,
-        "/E " ++ entry_point,
-        "/Fo " ++ shader_dir ++ output_filename,
-        "/T " ++ profile ++ "_" ++ shader_ver,
-        if (define.len == 0) "" else "/D " ++ define,
-        "/WX",
-        "/Ges",
-        "/O3",
-    };
-
-    const cmd_step = b.addSystemCommand(&dxc_command);
-    if (builtin.target.os.tag == .linux) {
-        cmd_step.setEnvironmentVariable(
-            "LD_LIBRARY_PATH",
-            thisDir() ++ "/../../libs/zwin32/bin/x64",
-        );
-    }
-    dxc_step.dependOn(&cmd_step.step);
-}
-
-inline fn thisDir() []const u8 {
-    return comptime std.fs.path.dirname(@src().file) orelse ".";
 }

--- a/samples/directml_convolution_test/build.zig
+++ b/samples/directml_convolution_test/build.zig
@@ -53,7 +53,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
         .install_subdir = b.pathJoin(&.{ "bin", content_dir }),
     });
     if (builtin.os.tag == .windows or builtin.os.tag == .linux) {
-        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name, .{ .shader_ver = "6_0" });
+        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name, .{ .shader_ver = "6_6" });
         const root_path = pathResolve(b, &.{ @src().file, "..", "..", ".." });
         const shaders_path = b.pathJoin(&.{ root_path, content_path, "shaders" });
 

--- a/samples/mesh_shader_test/build.zig
+++ b/samples/mesh_shader_test/build.zig
@@ -2,12 +2,21 @@ const builtin = @import("builtin");
 const std = @import("std");
 
 const Options = @import("../../build.zig").Options;
-const content_dir = "mesh_shader_test_content/";
+
+const demo_name = "mesh_shader_test";
+const content_dir = demo_name ++ "_content/";
+
+// in future zig version e342433
+pub fn pathResolve(b: *std.Build, paths: []const []const u8) []u8 {
+    return std.fs.path.resolve(b.allocator, paths) catch @panic("OOM");
+}
 
 pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
+    const cwd_path = b.pathJoin(&.{ "samples", demo_name });
+    const src_path = b.pathJoin(&.{ cwd_path, "src" });
     const exe = b.addExecutable(.{
-        .name = "mesh_shader_test",
-        .root_source_file = .{ .path = thisDir() ++ "/src/mesh_shader_test.zig" },
+        .name = demo_name,
+        .root_source_file = b.path(b.pathJoin(&.{ src_path, demo_name ++ ".zig" })),
         .target = options.target,
         .optimize = options.optimize,
     });
@@ -43,15 +52,30 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
+    const content_path = b.pathJoin(&.{ cwd_path, content_dir });
     const install_content_step = b.addInstallDirectory(.{
-        .source_dir = .{ .path = thisDir() ++ "/" ++ content_dir },
+        .source_dir = b.path(content_path),
         .install_dir = .{ .custom = "" },
-        .install_subdir = "bin/" ++ content_dir,
+        .install_subdir = b.pathJoin(&.{ "bin", content_dir }),
     });
     if (builtin.os.tag == .windows or builtin.os.tag == .linux) {
-        const dxc_step = buildShaders(b);
-        exe.step.dependOn(dxc_step);
-        install_content_step.step.dependOn(dxc_step);
+        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name, .{ .shader_ver = "6_6" });
+        const root_path = pathResolve(b, &.{ @src().file, "..", "..", ".." });
+        const shaders_path = b.pathJoin(&.{ root_path, content_path, "shaders" });
+
+        const common_hlsl_path = b.pathJoin(&.{ root_path, "samples", "common/src/hlsl/common.hlsl" });
+        compile_shaders.addVsShader(common_hlsl_path, "vsImGui", b.pathJoin(&.{ shaders_path, "imgui.vs.cso" }), "PSO__IMGUI");
+        compile_shaders.addPsShader(common_hlsl_path, "psImGui", b.pathJoin(&.{ shaders_path, "imgui.ps.cso" }), "PSO__IMGUI");
+
+        const hlsl_path = b.pathJoin(&.{ root_path, src_path, demo_name ++ ".hlsl" });
+        compile_shaders.addMsShader(hlsl_path, "msMain", b.pathJoin(&.{ shaders_path, "mesh_shader.ms.cso" }), "PSO__MESH_SHADER");
+        compile_shaders.addPsShader(hlsl_path, "psMain", b.pathJoin(&.{ shaders_path, "mesh_shader.ps.cso" }), "PSO__VERTEX_SHADER");
+        compile_shaders.addVsShader(hlsl_path, "vsMain", b.pathJoin(&.{ shaders_path, "vertex_shader.vs.cso" }), "PSO__VERTEX_SHADER");
+        compile_shaders.addPsShader(hlsl_path, "psMain", b.pathJoin(&.{ shaders_path, "vertex_shader.ps.cso" }), "PSO__VERTEX_SHADER");
+        compile_shaders.addVsShader(hlsl_path, "vsMain", b.pathJoin(&.{ shaders_path, "vertex_shader_fixed.vs.cso" }), "PSO__VERTEX_SHADER_FIXED");
+        compile_shaders.addPsShader(hlsl_path, "psMain", b.pathJoin(&.{ shaders_path, "vertex_shader_fixed.ps.cso" }), "PSO__VERTEX_SHADER_FIXED");
+
+        install_content_step.step.dependOn(compile_shaders.step);
     }
     exe.step.dependOn(&install_content_step.step);
 
@@ -63,127 +87,4 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     @import("zwin32").install_d3d12(&exe.step, .bin, "libs/zwin32") catch unreachable;
 
     return exe;
-}
-
-fn buildShaders(b: *std.Build) *std.Build.Step {
-    const dxc_step = b.step("mesh_shader_test-dxc", "Build shaders for 'mesh shader test' demo");
-
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "../common/src/hlsl/common.hlsl",
-        "vsImGui",
-        "imgui.vs.cso",
-        "vs",
-        "PSO__IMGUI",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "../common/src/hlsl/common.hlsl",
-        "psImGui",
-        "imgui.ps.cso",
-        "ps",
-        "PSO__IMGUI",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/mesh_shader_test.hlsl",
-        "msMain",
-        "mesh_shader.ms.cso",
-        "ms",
-        "PSO__MESH_SHADER",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/mesh_shader_test.hlsl",
-        "psMain",
-        "mesh_shader.ps.cso",
-        "ps",
-        "PSO__MESH_SHADER",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/mesh_shader_test.hlsl",
-        "vsMain",
-        "vertex_shader.vs.cso",
-        "vs",
-        "PSO__VERTEX_SHADER",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/mesh_shader_test.hlsl",
-        "psMain",
-        "vertex_shader.ps.cso",
-        "ps",
-        "PSO__VERTEX_SHADER",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/mesh_shader_test.hlsl",
-        "vsMain",
-        "vertex_shader_fixed.vs.cso",
-        "vs",
-        "PSO__VERTEX_SHADER_FIXED",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/mesh_shader_test.hlsl",
-        "psMain",
-        "vertex_shader_fixed.ps.cso",
-        "ps",
-        "PSO__VERTEX_SHADER_FIXED",
-    );
-
-    return dxc_step;
-}
-
-fn makeDxcCmd(
-    b: *std.Build,
-    dxc_step: *std.Build.Step,
-    comptime input_path: []const u8,
-    comptime entry_point: []const u8,
-    comptime output_filename: []const u8,
-    comptime profile: []const u8,
-    comptime define: []const u8,
-) void {
-    const shader_ver = "6_6";
-    const shader_dir = thisDir() ++ "/" ++ content_dir ++ "shaders/";
-
-    const dxc_path = switch (builtin.target.os.tag) {
-        .windows => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc.exe",
-        .linux => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc",
-        else => @panic("Unsupported target"),
-    };
-
-    const dxc_command = [9][]const u8{
-        dxc_path,
-        thisDir() ++ "/" ++ input_path,
-        "/E " ++ entry_point,
-        "/Fo " ++ shader_dir ++ output_filename,
-        "/T " ++ profile ++ "_" ++ shader_ver,
-        if (define.len == 0) "" else "/D " ++ define,
-        "/WX",
-        "/Ges",
-        "/O3",
-    };
-
-    const cmd_step = b.addSystemCommand(&dxc_command);
-    if (builtin.target.os.tag == .linux) {
-        cmd_step.setEnvironmentVariable(
-            "LD_LIBRARY_PATH",
-            thisDir() ++ "/../../libs/zwin32/bin/x64",
-        );
-    }
-    dxc_step.dependOn(&cmd_step.step);
-}
-
-inline fn thisDir() []const u8 {
-    return comptime std.fs.path.dirname(@src().file) orelse ".";
 }

--- a/samples/minimal_d3d12/build.zig
+++ b/samples/minimal_d3d12/build.zig
@@ -28,7 +28,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     exe.root_module.addImport("zwin32", zwin32.module("root"));
 
     if (builtin.os.tag == .windows or builtin.os.tag == .linux) {
-        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name, .{ .shader_ver = "6_0" });
+        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name, .{ .shader_ver = "6_6" });
         const root_path = pathResolve(b, &.{ @src().file, "..", "..", ".." });
 
         const hlsl_path = b.pathJoin(&.{ root_path, src_path, demo_name ++ ".hlsl" });

--- a/samples/minimal_d3d12/build.zig
+++ b/samples/minimal_d3d12/build.zig
@@ -3,10 +3,19 @@ const std = @import("std");
 
 const Options = @import("../../build.zig").Options;
 
+const demo_name = "minimal_d3d12";
+
+// in future zig version e342433
+pub fn pathResolve(b: *std.Build, paths: []const []const u8) []u8 {
+    return std.fs.path.resolve(b.allocator, paths) catch @panic("OOM");
+}
+
 pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
+    const cwd_path = b.pathJoin(&.{ "samples", demo_name });
+    const src_path = b.pathJoin(&.{ cwd_path, "src" });
     const exe = b.addExecutable(.{
-        .name = "minimal_d3d12",
-        .root_source_file = .{ .path = thisDir() ++ "/src/minimal_d3d12.zig" },
+        .name = demo_name,
+        .root_source_file = b.path(b.pathJoin(&.{ src_path, demo_name ++ ".zig" })),
         .target = options.target,
         .optimize = options.optimize,
     });
@@ -19,8 +28,14 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     exe.root_module.addImport("zwin32", zwin32.module("root"));
 
     if (builtin.os.tag == .windows or builtin.os.tag == .linux) {
-        const dxc_step = buildShaders(b);
-        exe.step.dependOn(dxc_step);
+        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name, .{ .shader_ver = "6_0" });
+        const root_path = pathResolve(b, &.{ @src().file, "..", "..", ".." });
+
+        const hlsl_path = b.pathJoin(&.{ root_path, src_path, demo_name ++ ".hlsl" });
+        compile_shaders.addVsShader(hlsl_path, "vsMain", b.pathJoin(&.{ root_path, src_path, demo_name ++ ".vs.cso" }), "");
+        compile_shaders.addPsShader(hlsl_path, "psMain", b.pathJoin(&.{ root_path, src_path, demo_name ++ ".ps.cso" }), "");
+
+        exe.step.dependOn(compile_shaders.step);
     }
 
     // This is needed to export symbols from an .exe file.
@@ -31,57 +46,4 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     @import("zwin32").install_d3d12(&exe.step, .bin, "libs/zwin32") catch unreachable;
 
     return exe;
-}
-
-fn buildShaders(b: *std.Build) *std.Build.Step {
-    const dxc_step = b.step("minimal_d3d12-dxc", "Build shaders for 'minimal d3d12' demo");
-
-    makeDxcCmd(b, dxc_step, "src/minimal_d3d12.hlsl", "vsMain", "minimal_d3d12.vs.cso", "vs", "");
-    makeDxcCmd(b, dxc_step, "src/minimal_d3d12.hlsl", "psMain", "minimal_d3d12.ps.cso", "ps", "");
-
-    return dxc_step;
-}
-
-fn makeDxcCmd(
-    b: *std.Build,
-    dxc_step: *std.Build.Step,
-    comptime input_path: []const u8,
-    comptime entry_point: []const u8,
-    comptime output_filename: []const u8,
-    comptime profile: []const u8,
-    comptime define: []const u8,
-) void {
-    const shader_ver = "6_0";
-    const shader_dir = thisDir() ++ "/src/";
-
-    const dxc_path = switch (builtin.target.os.tag) {
-        .windows => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc.exe",
-        .linux => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc",
-        else => @panic("Unsupported target"),
-    };
-
-    const dxc_command = [9][]const u8{
-        dxc_path,
-        thisDir() ++ "/" ++ input_path,
-        "/E " ++ entry_point,
-        "/Fo " ++ shader_dir ++ output_filename,
-        "/T " ++ profile ++ "_" ++ shader_ver,
-        if (define.len == 0) "" else "/D " ++ define,
-        "/WX",
-        "/Ges",
-        "/O3",
-    };
-
-    const cmd_step = b.addSystemCommand(&dxc_command);
-    if (builtin.target.os.tag == .linux) {
-        cmd_step.setEnvironmentVariable(
-            "LD_LIBRARY_PATH",
-            thisDir() ++ "/../../libs/zwin32/bin/x64",
-        );
-    }
-    dxc_step.dependOn(&cmd_step.step);
-}
-
-inline fn thisDir() []const u8 {
-    return comptime std.fs.path.dirname(@src().file) orelse ".";
 }

--- a/samples/minimal_glfw_d3d12/build.zig
+++ b/samples/minimal_glfw_d3d12/build.zig
@@ -6,10 +6,17 @@ const Options = @import("../../build.zig").Options;
 const demo_name = "minimal_glfw_d3d12";
 const content_dir = demo_name ++ "_content/";
 
+// in future zig version e342433
+pub fn pathResolve(b: *std.Build, paths: []const []const u8) []u8 {
+    return std.fs.path.resolve(b.allocator, paths) catch @panic("OOM");
+}
+
 pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
+    const cwd_path = b.pathJoin(&.{ "samples", demo_name });
+    const src_path = b.pathJoin(&.{ cwd_path, "src" });
     const exe = b.addExecutable(.{
         .name = demo_name,
-        .root_source_file = .{ .path = thisDir() ++ "/src/" ++ demo_name ++ ".zig" },
+        .root_source_file = b.path(b.pathJoin(&.{ src_path, demo_name ++ ".zig" })),
         .target = options.target,
         .optimize = options.optimize,
     });
@@ -36,15 +43,22 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     const zd3d12_module = zd3d12.module("root");
     exe.root_module.addImport("zd3d12", zd3d12_module);
 
+    const content_path = b.pathJoin(&.{ cwd_path, content_dir });
     const install_content_step = b.addInstallDirectory(.{
-        .source_dir = .{ .path = thisDir() ++ "/" ++ content_dir },
+        .source_dir = b.path(content_path),
         .install_dir = .{ .custom = "" },
-        .install_subdir = "bin/" ++ content_dir,
+        .install_subdir = b.pathJoin(&.{ "bin", content_dir }),
     });
 
     if (builtin.os.tag == .windows or builtin.os.tag == .linux) {
-        const dxc_step = buildShaders(b);
-        install_content_step.step.dependOn(dxc_step);
+        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name);
+        const root_path = pathResolve(b, &.{ @src().file, "..", "..", ".." });
+
+        const hlsl_path = b.pathJoin(&.{ root_path, src_path, demo_name ++ ".hlsl" });
+        compile_shaders.addVsShader(hlsl_path, "vsMain", b.pathJoin(&.{ root_path, content_path, demo_name ++ ".vs.cso" }), "");
+        compile_shaders.addPsShader(hlsl_path, "psMain", b.pathJoin(&.{ root_path, content_path, demo_name ++ ".ps.cso" }), "");
+
+        install_content_step.step.dependOn(compile_shaders.step);
     }
     exe.step.dependOn(&install_content_step.step);
 
@@ -60,57 +74,4 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
     return exe;
-}
-
-fn buildShaders(b: *std.Build) *std.Build.Step {
-    const dxc_step = b.step(demo_name ++ "-dxc", "Build shaders for '" ++ demo_name ++ "' demo");
-
-    makeDxcCmd(b, dxc_step, "src/" ++ demo_name ++ ".hlsl", "vsMain", demo_name ++ ".vs.cso", "vs", "");
-    makeDxcCmd(b, dxc_step, "src/" ++ demo_name ++ ".hlsl", "psMain", demo_name ++ ".ps.cso", "ps", "");
-
-    return dxc_step;
-}
-
-fn makeDxcCmd(
-    b: *std.Build,
-    dxc_step: *std.Build.Step,
-    comptime input_path: []const u8,
-    comptime entry_point: []const u8,
-    comptime output_filename: []const u8,
-    comptime profile: []const u8,
-    comptime define: []const u8,
-) void {
-    const shader_ver = "6_0";
-    const shader_dir = thisDir() ++ "/" ++ content_dir;
-
-    const dxc_path = switch (builtin.target.os.tag) {
-        .windows => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc.exe",
-        .linux => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc",
-        else => @panic("Unsupported target"),
-    };
-
-    const dxc_command = [9][]const u8{
-        dxc_path,
-        thisDir() ++ "/" ++ input_path,
-        "/E " ++ entry_point,
-        "/Fo " ++ shader_dir ++ output_filename,
-        "/T " ++ profile ++ "_" ++ shader_ver,
-        if (define.len == 0) "" else "/D " ++ define,
-        "/WX",
-        "/Ges",
-        "/O3",
-    };
-
-    const cmd_step = b.addSystemCommand(&dxc_command);
-    if (builtin.target.os.tag == .linux) {
-        cmd_step.setEnvironmentVariable(
-            "LD_LIBRARY_PATH",
-            thisDir() ++ "/../../libs/zwin32/bin/x64",
-        );
-    }
-    dxc_step.dependOn(&cmd_step.step);
-}
-
-inline fn thisDir() []const u8 {
-    return comptime std.fs.path.dirname(@src().file) orelse ".";
 }

--- a/samples/minimal_glfw_d3d12/build.zig
+++ b/samples/minimal_glfw_d3d12/build.zig
@@ -51,7 +51,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     });
 
     if (builtin.os.tag == .windows or builtin.os.tag == .linux) {
-        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name, .{ .shader_ver = "6_0" });
+        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name, .{ .shader_ver = "6_6" });
         const root_path = pathResolve(b, &.{ @src().file, "..", "..", ".." });
 
         const hlsl_path = b.pathJoin(&.{ root_path, src_path, demo_name ++ ".hlsl" });

--- a/samples/minimal_glfw_d3d12/build.zig
+++ b/samples/minimal_glfw_d3d12/build.zig
@@ -51,7 +51,7 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     });
 
     if (builtin.os.tag == .windows or builtin.os.tag == .linux) {
-        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name);
+        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name, .{ .shader_ver = "6_0" });
         const root_path = pathResolve(b, &.{ @src().file, "..", "..", ".." });
 
         const hlsl_path = b.pathJoin(&.{ root_path, src_path, demo_name ++ ".hlsl" });

--- a/samples/minimal_glfw_d3d12/src/minimal_glfw_d3d12.zig
+++ b/samples/minimal_glfw_d3d12/src/minimal_glfw_d3d12.zig
@@ -48,8 +48,8 @@ pub fn main() !void {
         pso_desc.RTVFormats[0] = .R8G8B8A8_UNORM;
         pso_desc.NumRenderTargets = 1;
         pso_desc.PrimitiveTopologyType = .TRIANGLE;
-        pso_desc.VS = d3d12.SHADER_BYTECODE.init(try std.fs.cwd().readFileAlloc(arena_allocator, content_dir ++ "/minimal_glfw_d3d12.vs.cso", 256 * 1024));
-        pso_desc.PS = d3d12.SHADER_BYTECODE.init(try std.fs.cwd().readFileAlloc(arena_allocator, content_dir ++ "/minimal_glfw_d3d12.ps.cso", 256 * 1024));
+        pso_desc.VS = d3d12.SHADER_BYTECODE.init(try std.fs.cwd().readFileAlloc(arena_allocator, content_dir ++ "minimal_glfw_d3d12.vs.cso", 256 * 1024));
+        pso_desc.PS = d3d12.SHADER_BYTECODE.init(try std.fs.cwd().readFileAlloc(arena_allocator, content_dir ++ "minimal_glfw_d3d12.ps.cso", 256 * 1024));
 
         break :pipeline gctx.createGraphicsShaderPipeline(&pso_desc);
     };

--- a/samples/rasterization/build.zig
+++ b/samples/rasterization/build.zig
@@ -2,12 +2,21 @@ const builtin = @import("builtin");
 const std = @import("std");
 
 const Options = @import("../../build.zig").Options;
-const content_dir = "rasterization_content/";
+
+const demo_name = "rasterization";
+const content_dir = demo_name ++ "_content/";
+
+// in future zig version e342433
+pub fn pathResolve(b: *std.Build, paths: []const []const u8) []u8 {
+    return std.fs.path.resolve(b.allocator, paths) catch @panic("OOM");
+}
 
 pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
+    const cwd_path = b.pathJoin(&.{ "samples", demo_name });
+    const src_path = b.pathJoin(&.{ cwd_path, "src" });
     const exe = b.addExecutable(.{
-        .name = "rasterization",
-        .root_source_file = .{ .path = thisDir() ++ "/src/rasterization.zig" },
+        .name = demo_name,
+        .root_source_file = b.path(b.pathJoin(&.{ src_path, demo_name ++ ".zig" })),
         .target = options.target,
         .optimize = options.optimize,
     });
@@ -48,15 +57,31 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
+    const content_path = b.pathJoin(&.{ cwd_path, content_dir });
     const install_content_step = b.addInstallDirectory(.{
-        .source_dir = .{ .path = thisDir() ++ "/" ++ content_dir },
+        .source_dir = b.path(content_path),
         .install_dir = .{ .custom = "" },
-        .install_subdir = "bin/" ++ content_dir,
+        .install_subdir = b.pathJoin(&.{ "bin", content_dir }),
     });
     if (builtin.os.tag == .windows or builtin.os.tag == .linux) {
-        const dxc_step = buildShaders(b);
-        exe.step.dependOn(dxc_step);
-        install_content_step.step.dependOn(dxc_step);
+        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name, .{ .shader_ver = "6_6" });
+        const root_path = pathResolve(b, &.{ @src().file, "..", "..", ".." });
+        const shaders_path = b.pathJoin(&.{ root_path, content_path, "shaders" });
+
+        const common_hlsl_path = b.pathJoin(&.{ root_path, "samples", "common/src/hlsl/common.hlsl" });
+        compile_shaders.addVsShader(common_hlsl_path, "vsImGui", b.pathJoin(&.{ shaders_path, "imgui.vs.cso" }), "PSO__IMGUI");
+        compile_shaders.addPsShader(common_hlsl_path, "psImGui", b.pathJoin(&.{ shaders_path, "imgui.ps.cso" }), "PSO__IMGUI");
+        compile_shaders.addCsShader(common_hlsl_path, "csGenerateMipmaps", b.pathJoin(&.{ shaders_path, "generate_mipmaps.ps.cso" }), "PSO__GENERATE_MIPMAPS");
+
+        const hlsl_path = b.pathJoin(&.{ root_path, src_path, demo_name ++ ".hlsl" });
+        compile_shaders.addVsShader(hlsl_path, "vsRecordPixels", b.pathJoin(&.{ shaders_path, "record_pixels.vs.cso" }), "PSO__RECORD_PIXELS");
+        compile_shaders.addPsShader(hlsl_path, "psRecordPixels", b.pathJoin(&.{ shaders_path, "record_pixels.ps.cso" }), "PSO__RECORD_PIXELS");
+        compile_shaders.addVsShader(hlsl_path, "vsDrawMesh", b.pathJoin(&.{ shaders_path, "draw_mesh.vs.cso" }), "PSO__DRAW_MESH");
+        compile_shaders.addPsShader(hlsl_path, "psDrawMesh", b.pathJoin(&.{ shaders_path, "draw_mesh.ps.cso" }), "PSO__DRAW_MESH");
+        compile_shaders.addCsShader(hlsl_path, "csDrawPixels", b.pathJoin(&.{ shaders_path, "draw_pixels.cs.cso" }), "PSO__DRAW_PIXELS");
+        compile_shaders.addCsShader(hlsl_path, "csClearPixels", b.pathJoin(&.{ shaders_path, "clear_pixels.cs.cso" }), "PSO__CLEAR_PIXELS");
+
+        install_content_step.step.dependOn(compile_shaders.step);
     }
     exe.step.dependOn(&install_content_step.step);
 
@@ -68,136 +93,4 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     @import("zwin32").install_d3d12(&exe.step, .bin, "libs/zwin32") catch unreachable;
 
     return exe;
-}
-
-fn buildShaders(b: *std.Build) *std.Build.Step {
-    const dxc_step = b.step("rasterization-dxc", "Build shaders for 'rasterization' demo");
-
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "../common/src/hlsl/common.hlsl",
-        "vsImGui",
-        "imgui.vs.cso",
-        "vs",
-        "PSO__IMGUI",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "../common/src/hlsl/common.hlsl",
-        "psImGui",
-        "imgui.ps.cso",
-        "ps",
-        "PSO__IMGUI",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "../common/src/hlsl/common.hlsl",
-        "csGenerateMipmaps",
-        "generate_mipmaps.cs.cso",
-        "cs",
-        "PSO__GENERATE_MIPMAPS",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/rasterization.hlsl",
-        "vsRecordPixels",
-        "record_pixels.vs.cso",
-        "vs",
-        "PSO__RECORD_PIXELS",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/rasterization.hlsl",
-        "psRecordPixels",
-        "record_pixels.ps.cso",
-        "ps",
-        "PSO__RECORD_PIXELS",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/rasterization.hlsl",
-        "vsDrawMesh",
-        "draw_mesh.vs.cso",
-        "vs",
-        "PSO__DRAW_MESH",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/rasterization.hlsl",
-        "psDrawMesh",
-        "draw_mesh.ps.cso",
-        "ps",
-        "PSO__DRAW_MESH",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/rasterization.hlsl",
-        "csDrawPixels",
-        "draw_pixels.cs.cso",
-        "cs",
-        "PSO__DRAW_PIXELS",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/rasterization.hlsl",
-        "csClearPixels",
-        "clear_pixels.cs.cso",
-        "cs",
-        "PSO__CLEAR_PIXELS",
-    );
-
-    return dxc_step;
-}
-
-fn makeDxcCmd(
-    b: *std.Build,
-    dxc_step: *std.Build.Step,
-    comptime input_path: []const u8,
-    comptime entry_point: []const u8,
-    comptime output_filename: []const u8,
-    comptime profile: []const u8,
-    comptime define: []const u8,
-) void {
-    const shader_ver = "6_6";
-    const shader_dir = thisDir() ++ "/" ++ content_dir ++ "shaders/";
-
-    const dxc_path = switch (builtin.target.os.tag) {
-        .windows => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc.exe",
-        .linux => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc",
-        else => @panic("Unsupported target"),
-    };
-
-    const dxc_command = [9][]const u8{
-        dxc_path,
-        thisDir() ++ "/" ++ input_path,
-        "/E " ++ entry_point,
-        "/Fo " ++ shader_dir ++ output_filename,
-        "/T " ++ profile ++ "_" ++ shader_ver,
-        if (define.len == 0) "" else "/D " ++ define,
-        "/WX",
-        "/Ges",
-        "/O3",
-    };
-
-    const cmd_step = b.addSystemCommand(&dxc_command);
-    if (builtin.target.os.tag == .linux) {
-        cmd_step.setEnvironmentVariable(
-            "LD_LIBRARY_PATH",
-            thisDir() ++ "/../../libs/zwin32/bin/x64",
-        );
-    }
-    dxc_step.dependOn(&cmd_step.step);
-}
-
-inline fn thisDir() []const u8 {
-    return comptime std.fs.path.dirname(@src().file) orelse ".";
 }

--- a/samples/textured_quad/build.zig
+++ b/samples/textured_quad/build.zig
@@ -2,12 +2,21 @@ const builtin = @import("builtin");
 const std = @import("std");
 
 const Options = @import("../../build.zig").Options;
-const content_dir = "textured_quad_content/";
+
+const demo_name = "textured_quad";
+const content_dir = demo_name ++ "_content/";
+
+// in future zig version e342433
+pub fn pathResolve(b: *std.Build, paths: []const []const u8) []u8 {
+    return std.fs.path.resolve(b.allocator, paths) catch @panic("OOM");
+}
 
 pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
+    const cwd_path = b.pathJoin(&.{ "samples", demo_name });
+    const src_path = b.pathJoin(&.{ cwd_path, "src" });
     const exe = b.addExecutable(.{
-        .name = "textured_quad",
-        .root_source_file = .{ .path = thisDir() ++ "/src/textured_quad.zig" },
+        .name = demo_name,
+        .root_source_file = b.path(b.pathJoin(&.{ src_path, demo_name ++ ".zig" })),
         .target = options.target,
         .optimize = options.optimize,
     });
@@ -37,15 +46,28 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
+    const content_path = b.pathJoin(&.{ cwd_path, content_dir });
     const install_content_step = b.addInstallDirectory(.{
-        .source_dir = .{ .path = thisDir() ++ "/" ++ content_dir },
+        .source_dir = b.path(content_path),
         .install_dir = .{ .custom = "" },
-        .install_subdir = "bin/" ++ content_dir,
+        .install_subdir = b.pathJoin(&.{ "bin", content_dir }),
     });
+
     if (builtin.os.tag == .windows or builtin.os.tag == .linux) {
-        const dxc_step = buildShaders(b);
-        exe.step.dependOn(dxc_step);
-        install_content_step.step.dependOn(dxc_step);
+        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name, .{ .shader_ver = "6_6" });
+        const root_path = pathResolve(b, &.{ @src().file, "..", "..", ".." });
+        const shaders_path = b.pathJoin(&.{ root_path, content_path, "shaders" });
+
+        const common_hlsl_path = b.pathJoin(&.{ root_path, "samples", "common/src/hlsl/common.hlsl" });
+        compile_shaders.addVsShader(common_hlsl_path, "vsImGui", b.pathJoin(&.{ shaders_path, "imgui.vs.cso" }), "PSO__IMGUI");
+        compile_shaders.addPsShader(common_hlsl_path, "psImGui", b.pathJoin(&.{ shaders_path, "imgui.ps.cso" }), "PSO__IMGUI");
+        compile_shaders.addCsShader(common_hlsl_path, "csGenerateMipmaps", b.pathJoin(&.{ shaders_path, "generate_mipmaps.ps.cso" }), "PSO__GENERATE_MIPMAPS");
+
+        const hlsl_path = b.pathJoin(&.{ root_path, src_path, demo_name ++ ".hlsl" });
+        compile_shaders.addVsShader(hlsl_path, "vsMain", b.pathJoin(&.{ shaders_path, demo_name ++ ".vs.cso" }), "");
+        compile_shaders.addPsShader(hlsl_path, "psMain", b.pathJoin(&.{ shaders_path, demo_name ++ ".ps.cso" }), "");
+
+        install_content_step.step.dependOn(compile_shaders.step);
     }
     exe.step.dependOn(&install_content_step.step);
 
@@ -57,100 +79,4 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     @import("zwin32").install_d3d12(&exe.step, .bin, "libs/zwin32") catch unreachable;
 
     return exe;
-}
-
-fn buildShaders(b: *std.Build) *std.Build.Step {
-    const dxc_step = b.step("textured_quad-dxc", "Build shaders for 'textured quad' demo");
-
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "../common/src/hlsl/common.hlsl",
-        "vsImGui",
-        "imgui.vs.cso",
-        "vs",
-        "PSO__IMGUI",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "../common/src/hlsl/common.hlsl",
-        "psImGui",
-        "imgui.ps.cso",
-        "ps",
-        "PSO__IMGUI",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "../common/src/hlsl/common.hlsl",
-        "csGenerateMipmaps",
-        "generate_mipmaps.cs.cso",
-        "cs",
-        "PSO__GENERATE_MIPMAPS",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/textured_quad.hlsl",
-        "vsMain",
-        "textured_quad.vs.cso",
-        "vs",
-        "",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "src/textured_quad.hlsl",
-        "psMain",
-        "textured_quad.ps.cso",
-        "ps",
-        "",
-    );
-
-    return dxc_step;
-}
-
-fn makeDxcCmd(
-    b: *std.Build,
-    dxc_step: *std.Build.Step,
-    comptime input_path: []const u8,
-    comptime entry_point: []const u8,
-    comptime output_filename: []const u8,
-    comptime profile: []const u8,
-    comptime define: []const u8,
-) void {
-    const shader_ver = "6_6";
-    const shader_dir = thisDir() ++ "/" ++ content_dir ++ "shaders/";
-
-    const dxc_path = switch (builtin.target.os.tag) {
-        .windows => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc.exe",
-        .linux => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc",
-        else => @panic("Unsupported target"),
-    };
-
-    const dxc_command = [9][]const u8{
-        dxc_path,
-        thisDir() ++ "/" ++ input_path,
-        "/E " ++ entry_point,
-        "/Fo " ++ shader_dir ++ output_filename,
-        "/T " ++ profile ++ "_" ++ shader_ver,
-        if (define.len == 0) "" else "/D " ++ define,
-        "/WX",
-        "/Ges",
-        "/O3",
-    };
-
-    const cmd_step = b.addSystemCommand(&dxc_command);
-    if (builtin.target.os.tag == .linux) {
-        cmd_step.setEnvironmentVariable(
-            "LD_LIBRARY_PATH",
-            thisDir() ++ "/../../libs/zwin32/bin/x64",
-        );
-    }
-    dxc_step.dependOn(&cmd_step.step);
-}
-
-inline fn thisDir() []const u8 {
-    return comptime std.fs.path.dirname(@src().file) orelse ".";
 }

--- a/samples/triangle/build.zig
+++ b/samples/triangle/build.zig
@@ -2,12 +2,21 @@ const builtin = @import("builtin");
 const std = @import("std");
 
 const Options = @import("../../build.zig").Options;
-const content_dir = "triangle_content/";
+
+const demo_name = "triangle";
+const content_dir = demo_name ++ "_content/";
+
+// in future zig version e342433
+pub fn pathResolve(b: *std.Build, paths: []const []const u8) []u8 {
+    return std.fs.path.resolve(b.allocator, paths) catch @panic("OOM");
+}
 
 pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
+    const cwd_path = b.pathJoin(&.{ "samples", demo_name });
+    const src_path = b.pathJoin(&.{ cwd_path, "src" });
     const exe = b.addExecutable(.{
-        .name = "triangle",
-        .root_source_file = .{ .path = thisDir() ++ "/src/triangle.zig" },
+        .name = demo_name,
+        .root_source_file = b.path(b.pathJoin(&.{ src_path, demo_name ++ ".zig" })),
         .target = options.target,
         .optimize = options.optimize,
     });
@@ -37,15 +46,20 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "content_dir", content_dir);
 
+    const content_path = b.pathJoin(&.{ cwd_path, content_dir });
     const install_content_step = b.addInstallDirectory(.{
-        .source_dir = .{ .path = thisDir() ++ "/" ++ content_dir },
+        .source_dir = b.path(content_path),
         .install_dir = .{ .custom = "" },
-        .install_subdir = "bin/" ++ content_dir,
+        .install_subdir = b.pathJoin(&.{ "bin", content_dir }),
     });
     if (builtin.os.tag == .windows or builtin.os.tag == .linux) {
-        const dxc_step = buildShaders(b);
-        exe.step.dependOn(dxc_step);
-        install_content_step.step.dependOn(dxc_step);
+        const compile_shaders = @import("zwin32").addCompileShaders(b, demo_name, .{ .shader_ver = "6_6" });
+        const root_path = pathResolve(b, &.{ @src().file, "..", "..", ".." });
+        const shaders_path = b.pathJoin(&.{ root_path, content_path, "shaders" });
+
+        const common_hlsl_path = b.pathJoin(&.{ root_path, "samples", "common/src/hlsl/common.hlsl" });
+        compile_shaders.addVsShader(common_hlsl_path, "vsImGui", b.pathJoin(&.{ shaders_path, "imgui.vs.cso" }), "PSO__IMGUI");
+        compile_shaders.addPsShader(common_hlsl_path, "psImGui", b.pathJoin(&.{ shaders_path, "imgui.ps.cso" }), "PSO__IMGUI");
     }
     exe.step.dependOn(&install_content_step.step);
 
@@ -57,75 +71,4 @@ pub fn build(b: *std.Build, options: Options) *std.Build.Step.Compile {
     @import("zwin32").install_d3d12(&exe.step, .bin, "libs/zwin32") catch unreachable;
 
     return exe;
-}
-
-fn buildShaders(b: *std.Build) *std.Build.Step {
-    const dxc_step = b.step("triangle-dxc", "Build shaders for 'triangle' demo");
-
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "../common/src/hlsl/common.hlsl",
-        "vsImGui",
-        "imgui.vs.cso",
-        "vs",
-        "PSO__IMGUI",
-    );
-    makeDxcCmd(
-        b,
-        dxc_step,
-        "../common/src/hlsl/common.hlsl",
-        "psImGui",
-        "imgui.ps.cso",
-        "ps",
-        "PSO__IMGUI",
-    );
-    makeDxcCmd(b, dxc_step, "src/triangle.hlsl", "vsTriangle", "triangle.vs.cso", "vs", "");
-    makeDxcCmd(b, dxc_step, "src/triangle.hlsl", "psTriangle", "triangle.ps.cso", "ps", "");
-
-    return dxc_step;
-}
-
-fn makeDxcCmd(
-    b: *std.Build,
-    dxc_step: *std.Build.Step,
-    comptime input_path: []const u8,
-    comptime entry_point: []const u8,
-    comptime output_filename: []const u8,
-    comptime profile: []const u8,
-    comptime define: []const u8,
-) void {
-    const shader_ver = "6_6";
-    const shader_dir = thisDir() ++ "/" ++ content_dir ++ "shaders/";
-
-    const dxc_path = switch (builtin.target.os.tag) {
-        .windows => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc.exe",
-        .linux => thisDir() ++ "/../../libs/zwin32/bin/x64/dxc",
-        else => @panic("Unsupported target"),
-    };
-
-    const dxc_command = [9][]const u8{
-        dxc_path,
-        thisDir() ++ "/" ++ input_path,
-        "/E " ++ entry_point,
-        "/Fo " ++ shader_dir ++ output_filename,
-        "/T " ++ profile ++ "_" ++ shader_ver,
-        if (define.len == 0) "" else "/D " ++ define,
-        "/WX",
-        "/Ges",
-        "/O3",
-    };
-
-    const cmd_step = b.addSystemCommand(&dxc_command);
-    if (builtin.target.os.tag == .linux) {
-        cmd_step.setEnvironmentVariable(
-            "LD_LIBRARY_PATH",
-            thisDir() ++ "/../../libs/zwin32/bin/x64",
-        );
-    }
-    dxc_step.dependOn(&cmd_step.step);
-}
-
-inline fn thisDir() []const u8 {
-    return comptime std.fs.path.dirname(@src().file) orelse ".";
 }


### PR DESCRIPTION
Also fixes some instances of https://github.com/zig-gamedev/zig-gamedev/issues/596

When we update to [`zig e342433`](https://github.com/ziglang/zig/commit/e3424332d3fa1264e1f6861b76bb0d1b2996728d#diff-355d0d5a29153bf7f7f73e8e64f0b467b26b2c37e824dcc47e872038a58ce855R1666) we can replace `pathResolve` with `b.pathResolve`