### PR TITLE
Add custom zpool handle methods

### DIFF
--- a/libs/zgpu/src/zgpu.zig
+++ b/libs/zgpu/src/zgpu.zig
@@ -1392,7 +1392,7 @@ const PipelineLayoutPool = ResourcePool(PipelineLayoutInfo, wgpu.PipelineLayout)
 
 fn ResourcePool(comptime Info: type, comptime Resource: type) type {
     const zpool = @import("zpool");
-    const Pool = zpool.Pool(16, 16, Resource, struct { info: Info });
+    const Pool = zpool.Pool(16, 16, Resource, struct { info: Info }, struct {});
 
     return struct {
         const Self = @This();

--- a/libs/zpool/src/handle.zig
+++ b/libs/zpool/src/handle.zig
@@ -45,6 +45,7 @@ pub fn Handle(
     comptime index_bits: u8,
     comptime cycle_bits: u8,
     comptime TResource: type,
+    comptime THandleMethods: type,
 ) type {
     if (index_bits == 0) @compileError("index_bits must be greater than 0");
     if (cycle_bits == 0) @compileError("cycle_bits must be greater than 0");
@@ -69,6 +70,8 @@ pub fn Handle(
 
     return extern struct {
         const Self = @This();
+
+        pub usingnamespace THandleMethods;
 
         const HandleType = Self;
         const IndexType = UInt(index_bits);
@@ -163,7 +166,7 @@ test "Handle sizes and alignments" {
     const expectEqual = std.testing.expectEqual;
 
     {
-        const H = Handle(4, 4, void);
+        const H = Handle(4, 4, void, struct {});
         try expectEqual(@sizeOf(u8), @sizeOf(H));
         try expectEqual(@alignOf(u8), @alignOf(H));
         try expectEqual(4, @bitSizeOf(H.IndexType));
@@ -177,7 +180,7 @@ test "Handle sizes and alignments" {
     }
 
     {
-        const H = Handle(6, 2, void);
+        const H = Handle(6, 2, void, struct {});
         try expectEqual(@sizeOf(u8), @sizeOf(H));
         try expectEqual(@alignOf(u8), @alignOf(H));
         try expectEqual(6, @bitSizeOf(H.IndexType));
@@ -191,7 +194,7 @@ test "Handle sizes and alignments" {
     }
 
     {
-        const H = Handle(8, 8, void);
+        const H = Handle(8, 8, void, struct {});
         try expectEqual(@sizeOf(u16), @sizeOf(H));
         try expectEqual(@alignOf(u16), @alignOf(H));
         try expectEqual(8, @bitSizeOf(H.IndexType));
@@ -205,7 +208,7 @@ test "Handle sizes and alignments" {
     }
 
     {
-        const H = Handle(12, 4, void);
+        const H = Handle(12, 4, void, struct {});
         try expectEqual(@sizeOf(u16), @sizeOf(H));
         try expectEqual(@alignOf(u16), @alignOf(H));
         try expectEqual(12, @bitSizeOf(H.IndexType));
@@ -219,7 +222,7 @@ test "Handle sizes and alignments" {
     }
 
     {
-        const H = Handle(16, 16, void);
+        const H = Handle(16, 16, void, struct {});
         try expectEqual(@sizeOf(u32), @sizeOf(H));
         try expectEqual(@alignOf(u32), @alignOf(H));
         try expectEqual(16, @bitSizeOf(H.IndexType));
@@ -233,7 +236,7 @@ test "Handle sizes and alignments" {
     }
 
     {
-        const H = Handle(22, 10, void);
+        const H = Handle(22, 10, void, struct {});
         try expectEqual(@sizeOf(u32), @sizeOf(H));
         try expectEqual(@alignOf(u32), @alignOf(H));
         try expectEqual(22, @bitSizeOf(H.IndexType));
@@ -252,7 +255,7 @@ test "Handle sizes and alignments" {
 test "Handle sort order" {
     const expect = std.testing.expect;
 
-    const handle = Handle(4, 4, void).init;
+    const handle = Handle(4, 4, void, struct {}).init;
     const a = handle(0, 3);
     const b = handle(1, 1);
 
@@ -269,7 +272,7 @@ test "Handle.format()" {
     const expectEqualStrings = std.testing.expectEqualStrings;
 
     const Foo = struct {};
-    const H = Handle(12, 4, Foo);
+    const H = Handle(12, 4, Foo, struct {});
     const h = H.init(0, 1);
 
     var buffer = [_]u8{0} ** 128;


### PR DESCRIPTION
This PR proposes a small change that adds the ability to define custom methods in the handle namespace of `zpool`.
While working with `zpool`, I found myself wanting to have a cleaner and shorter way of working with the handles.
This is subjective and I am not saying that this is better or that this is how things should be.

I wanted to turn code like:
`texture_pool.getColumnPtr(handle, .texture);`
into
`handle.getPtr();`
or turn code like:
```
texture_pool.requireLiveHandle(handle);
texture_pool.remove(handle);
```
into
`handle.release();`

For more details, have a look at the last test `Pool with custom handle methods` in the `pool.zig` file, where I give a more comprehensive example of a `TextureSystem` that ends up with a clean api thanks to the proposed change.

I'm sure that this could be achieved in a cleaner and more non-breaking way via some zig comptime magic or if creating a Pool takes a single struct parameter with the THandleMethods initialized to an empty struct so you only specify it if you want to add custom methods to the handle.

I am open to learning if all this is not a good idea and why.