### PR TITLE
zgui: remove a redundant installArtifact call, add `setWindowFocus`

### DIFF
--- a/libs/zgui/build.zig
+++ b/libs/zgui/build.zig
@@ -60,7 +60,6 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         });
 
-        b.installArtifact(lib);
         if (target.result.os.tag == .windows) {
             lib.defineCMacro("IMGUI_API", "__declspec(dllexport)");
             lib.defineCMacro("IMPLOT_API", "__declspec(dllexport)");

--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -679,7 +679,12 @@ pub fn setNextWindowBgAlpha(args: SetNextWindowBgAlpha) void {
     zguiSetNextWindowBgAlpha(args.alpha);
 }
 extern fn zguiSetNextWindowBgAlpha(alpha: f32) void;
-
+//--------------------------------------------------------------------------------------------------
+pub fn setWindowFocus(name: ?[:0]const u8) void {
+    zguiSetWindowFocus(name orelse null);
+}
+extern fn zguiSetWindowFocus(name: ?[*:0]const u8) void;
+//-------------------------------------------------------------------------------------------------
 pub fn setKeyboardFocusHere(offset: i32) void {
     zguiSetKeyboardFocusHere(offset);
 }

--- a/libs/zgui/src/zgui.cpp
+++ b/libs/zgui/src/zgui.cpp
@@ -61,6 +61,10 @@ ZGUI_API void zguiSetNextWindowBgAlpha(float alpha) {
     ImGui::SetNextWindowBgAlpha(alpha);
 }
 
+ZGUI_API void zguiSetWindowFocus(const char* name) {
+    ImGui::SetWindowFocus(name);
+}
+
 ZGUI_API void zguiSetKeyboardFocusHere(int offset) {
     ImGui::SetKeyboardFocusHere(offset);
 }


### PR DESCRIPTION
This extra call was causing `artifact("imgui")` calls to fail with an ambiguous artifact error (since "imgui" was being exposed twice).

Also added `setWindowFocus`.
