### PR TITLE
simple_openvr: fixed double free on shared root signature

### DIFF
--- a/samples/simple_openvr/src/simple_openvr.zig
+++ b/samples/simple_openvr/src/simple_openvr.zig
@@ -567,6 +567,7 @@ pub fn main() !void {
                 .InstanceDataStepRate = 0,
             },
         });
+        _ = root_signature.AddRef();
         pso_desc.pRootSignature = root_signature;
         pso_desc.VS = d3d12.SHADER_BYTECODE.init(try std.fs.cwd().readFileAlloc(arena_allocator, content_dir ++ "/shaders/companion.vs.cso", 256 * 1024));
         pso_desc.PS = d3d12.SHADER_BYTECODE.init(try std.fs.cwd().readFileAlloc(arena_allocator, content_dir ++ "/shaders/companion.ps.cso", 256 * 1024));
@@ -669,6 +670,7 @@ pub fn main() !void {
                 .InstanceDataStepRate = 0,
             },
         });
+        _ = root_signature.AddRef();
         pso_desc.pRootSignature = root_signature;
         pso_desc.VS = d3d12.SHADER_BYTECODE.init(try std.fs.cwd().readFileAlloc(arena_allocator, content_dir ++ "/shaders/axes.vs.cso", 256 * 1024));
         pso_desc.PS = d3d12.SHADER_BYTECODE.init(try std.fs.cwd().readFileAlloc(arena_allocator, content_dir ++ "/shaders/axes.ps.cso", 256 * 1024));
@@ -756,6 +758,7 @@ pub fn main() !void {
                 .InstanceDataStepRate = 0,
             },
         });
+        _ = root_signature.AddRef();
         pso_desc.pRootSignature = root_signature;
         pso_desc.VS = d3d12.SHADER_BYTECODE.init(try std.fs.cwd().readFileAlloc(arena_allocator, content_dir ++ "/shaders/render_model.vs.cso", 256 * 1024));
         pso_desc.PS = d3d12.SHADER_BYTECODE.init(try std.fs.cwd().readFileAlloc(arena_allocator, content_dir ++ "/shaders/render_model.ps.cso", 256 * 1024));


### PR DESCRIPTION
simple_openvr sample uses a shared root signature.

[d3d12 encourages shared root signatures across pipelines](https://learn.microsoft.com/en-us/windows/win32/direct3d12/root-signatures-overview):
> Ideally, there are groups of Pipeline State Objects (PSOs) that share the same root signature.

[zd3d12 supports shared root signatures](https://github.com/zig-gamedev/zig-gamedev/blob/04b92ef1ca48e07994557edcdae10bd6f86abf9c/libs/zd3d12/src/zd3d12.zig#L1240) on the `GRAPHICS_PIPELINE_STATE_DESC` passed into `createGraphicsShaderPipeline`.

When [`PipelinePool.deinit`](https://github.com/zig-gamedev/zig-gamedev/blob/04b92ef1ca48e07994557edcdae10bd6f86abf9c/libs/zd3d12/src/zd3d12.zig#L2338) it iterates over the pipelines and calls `IRootSignature.Release`.  When [`IRootSignature.Release`](https://learn.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-release) count goes to zero, the root signature is deallocated.

This PR fixes the bug where the shared root signature didn't increase the ref count for each additional shared usage. This was difficult to detect as the corruption happens randomly.

We only need to call `AddRef` 3 times even though the root signature is used in 4 pipelines as the ref count starts at 1.