### PR TITLE
Update zsdl example

### DIFF
--- a/libs/zsdl/README.md
+++ b/libs/zsdl/README.md
@@ -19,7 +19,7 @@ pub fn build(b: *std.Build) !void {
     @import("zsdl").addLibraryPathsTo(exe);
     @import("zsdl").link_SDL2(exe);
 
-    @import("zsdl").install_sdl2(&exe.step, options.target.result, .bin);
+    @import("zsdl").install_sdl2(&exe.step, target.result, .bin);
 }
 ```
 

--- a/libs/zsdl/README.md
+++ b/libs/zsdl/README.md
@@ -14,14 +14,12 @@ pub fn build(b: *std.Build) !void {
     const exe = b.addExecutable(.{ ... });
 
     const zsdl = b.dependency("zsdl", .{});
-    const zsdl_path = zsdl.path("").getPath(b);
-
     exe.root_module.addImport("zsdl2", zsdl.module("zsdl2"));
 
-    try @import("zsdl").addLibraryPathsTo(exe, zsdl_path);
+    @import("zsdl").addLibraryPathsTo(exe);
     @import("zsdl").link_SDL2(exe);
 
-    try @import("zsdl").install_sdl2(&exe.step, options.target.result, .bin, zsdl_path);
+    @import("zsdl").install_sdl2(&exe.step, options.target.result, .bin);
 }
 ```
 


### PR DESCRIPTION
It seems like the build methods from zsdl don't need the `zsdl_path` parameter anymore. Otherwise Zig throws an error.