### PR TITLE
Include macos system sdk and ignore enum warnings

### DIFF
--- a/libs/zgui/build.zig
+++ b/libs/zgui/build.zig
@@ -51,7 +51,7 @@ pub fn build(b: *std.Build) void {
         },
     });
 
-    const cflags = &.{"-fno-sanitize=undefined"};
+    const cflags = &.{ "-fno-sanitize=undefined", "-Wno-elaborated-enum-base" };
 
     const imgui = if (options.shared) blk: {
         const lib = b.addSharedLibrary(.{
@@ -247,6 +247,12 @@ pub fn build(b: *std.Build) void {
             });
         },
         .no_backend => {},
+    }
+
+    if (target.result.os.tag == .macos) {
+        const system_sdk = b.dependency("system_sdk", .{});
+        imgui.addSystemIncludePath(system_sdk.path("macos12/usr/include"));
+        imgui.addFrameworkPath(system_sdk.path("macos12/System/Library/Frameworks"));
     }
 
     const test_step = b.step("test", "Run zgui tests");

--- a/libs/zgui/build.zig.zon
+++ b/libs/zgui/build.zig.zon
@@ -11,5 +11,6 @@
     .dependencies = .{
         .zglfw = .{ .path = "../zglfw" },
         .zgpu = .{ .path = "../zgpu" },
+        .system_sdk = .{ .path = "../system-sdk" },
     },
 }


### PR DESCRIPTION
Fixes #628 

Added the includes imgui was looking for when specifically targeting macos.

Also ran into a warning with enums in the system-sdk. It seems to be just a warning that can be silenced with
[this argument](https://github.com/microsoft/vscode-cpptools/issues/10569). Maybe this flag should be macos specific?