### PR TITLE
Support zigglgen

### DIFF
--- a/libs/zglfw/src/zglfw.zig
+++ b/libs/zglfw/src/zglfw.zig
@@ -142,10 +142,12 @@ extern fn glfwGetCurrentContext() *Window;
 pub const swapInterval = glfwSwapInterval;
 extern fn glfwSwapInterval(interval: i32) void;
 
-pub const GlProc = *const anyopaque;
+pub const GlProc = *const fn () callconv(if (builtin.os.tag == .windows and builtin.cpu.arch == .x86) .Stdcall else .C) void;
 
-pub fn getProcAddress(procname: [:0]const u8) ?GlProc {
-    return glfwGetProcAddress(procname);
+
+pub fn getProcAddress(proc_name: [*:0]const u8) callconv(.C) ?GlProc {
+    if (glfwGetProcAddress(proc_name)) |proc_address| return proc_address;
+    return null;
 }
 extern fn glfwGetProcAddress(procname: [*:0]const u8) ?GlProc;
 

--- a/libs/zopengl/src/zopengl.zig
+++ b/libs/zopengl/src/zopengl.zig
@@ -12,7 +12,7 @@ test {
 pub const bindings = @import("bindings.zig");
 pub const wrapper = @import("wrapper.zig").Wrap(bindings);
 
-pub const LoaderFn = *const fn ([:0]const u8) ?*const anyopaque;
+pub const LoaderFn = *const fn ([*:0]const u8) callconv(.C) ?*const fn () callconv(.C) void;
 
 pub const Extension = enum {
     KHR_debug,


### PR DESCRIPTION
I was trying to use zglfw in combination with [zigglgen](https://github.com/castholm/zigglgen). Turned out to get it working, it only needed a more specific type of `GlProc` in zglfw. Then also a change in `zopengl` was needed to be able to build and run the zglfw/gl samples in zig-gamedev.

Not quite sure about potential flaws (or potential issues) of this type change, so I'm opening a PR here to discuss.