### PR TITLE
zopengl, zglfw, zsdl: getProcAddress fix name arg type

### DIFF
--- a/libs/zglfw/src/zglfw.zig
+++ b/libs/zglfw/src/zglfw.zig
@@ -149,7 +149,7 @@ extern fn glfwSwapInterval(interval: i32) void;
 
 pub const GlProc = *const anyopaque;
 
-pub fn getProcAddress(procname: [:0]const u8) ?GlProc {
+pub fn getProcAddress(procname: [*:0]const u8) ?GlProc {
     return glfwGetProcAddress(procname);
 }
 extern fn glfwGetProcAddress(procname: [*:0]const u8) ?GlProc;

--- a/libs/zopengl/src/zopengl.zig
+++ b/libs/zopengl/src/zopengl.zig
@@ -11,7 +11,7 @@ comptime {
 pub const bindings = @import("bindings.zig");
 pub const wrapper = @import("wrapper.zig").Wrap(bindings);
 
-pub const LoaderFn = *const fn ([:0]const u8) ?*const anyopaque;
+pub const LoaderFn = *const fn ([*:0]const u8) ?*const anyopaque;
 
 pub const Extension = enum {
     KHR_debug,

--- a/libs/zsdl/src/sdl2.zig
+++ b/libs/zsdl/src/sdl2.zig
@@ -321,7 +321,7 @@ pub const gl = struct {
     pub const swapWindow = SDL_GL_SwapWindow;
     extern fn SDL_GL_SwapWindow(window: *Window) void;
 
-    pub fn getProcAddress(proc: [:0]const u8) FunctionPointer {
+    pub fn getProcAddress(proc: [*:0]const u8) FunctionPointer {
         return SDL_GL_GetProcAddress(proc);
     }
     extern fn SDL_GL_GetProcAddress(proc: ?[*:0]const u8) FunctionPointer;

--- a/libs/zsdl/src/sdl3.zig
+++ b/libs/zsdl/src/sdl3.zig
@@ -318,7 +318,7 @@ pub const gl = struct {
     }
     extern fn SDL_GL_SwapWindow(window: *Window) c_int;
 
-    pub fn getProcAddress(proc: [:0]const u8) FunctionPointer {
+    pub fn getProcAddress(proc: [*:0]const u8) FunctionPointer {
         return SDL_GL_GetProcAddress(proc);
     }
     extern fn SDL_GL_GetProcAddress(proc: ?[*:0]const u8) FunctionPointer;


### PR DESCRIPTION
Small fix to type as discussed here: https://github.com/zig-gamedev/zig-gamedev/pull/646