### PR TITLE
zphysics: shared library support

### DIFF
--- a/libs/zglfw/src/zglfw.zig
+++ b/libs/zglfw/src/zglfw.zig
@@ -1048,7 +1048,6 @@ fn _isLinuxDesktopLike() bool {
     return switch (builtin.target.os.tag) {
         .linux,
         .freebsd,
-        .kfreebsd,
         .openbsd,
         .dragonfly,
         => true,

--- a/libs/zphysics/README.md
+++ b/libs/zphysics/README.md
@@ -106,3 +106,20 @@ pub fn main() !void {
     }
 }
 ```
+
+## Usage in a shared library
+
+The `joltc` artifact can be built as a shared library by specifying the `shared` build option:
+
+```
+    const zphysics = b.dependency("zphysics", .{
+        .shared = true,
+    });
+```
+
+If your zig module uses `zphysics` and is itself part of a shared library that is reloaded at runtime, then some additional steps are required:
+
+- Before unloading the shared library, call `preUnload` to export the internal global state
+- After reloading the shared library, call `postReload` to import the internal state and update allocator vtables
+
+If you use `registerTrace` or `registerAssertFailed`, these must also be called again to update their function pointers.

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
@@ -450,17 +450,10 @@ static inline void storeMat44(float out[16], JPH::Mat44Arg in) {
     in.StoreFloat4x4(reinterpret_cast<JPH::Float4 *>(out));
 }
 
+static JPH::TraceFunction default_trace = nullptr;
+
 #ifdef JPH_ENABLE_ASSERTS
-
-static bool
-AssertFailedImpl(const char *in_expression,
-                 const char *in_message,
-                 const char *in_file,
-                 uint32_t in_line)
-{
-	return true;
-}
-
+static JPH::AssertFailedFunction default_assert_failed = nullptr;
 #endif
 //--------------------------------------------------------------------------------------------------
 JPC_API void
@@ -480,6 +473,30 @@ JPC_RegisterCustomAllocator(JPC_AllocateFunction in_alloc,
     JPH::Free = in_free;
     JPH::AlignedAllocate = in_aligned_alloc;
     JPH::AlignedFree = in_aligned_free;
+#endif
+}
+
+JPC_API void
+JPC_RegisterTrace(JPC_TraceFunction in_trace)
+{
+    if (default_trace == nullptr)
+    {
+        default_trace = JPH::Trace;
+    }
+
+    JPH::Trace = in_trace ? in_trace : default_trace;
+}
+
+JPC_API void
+JPC_RegisterAssertFailed(JPC_AssertFailedFunction in_assert_failed)
+{
+#ifdef JPH_ENABLE_ASSERTS
+    if (default_assert_failed == nullptr)
+    {
+        default_assert_failed = JPH::AssertFailed;
+    }
+
+    JPH::AssertFailed = in_assert_failed ? in_assert_failed : default_assert_failed;
 #endif
 }
 //--------------------------------------------------------------------------------------------------

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.h
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.h
@@ -11,7 +11,9 @@
 // Const
 //
 //--------------------------------------------------------------------------------------------------
-#define JPC_API // TODO: Define this properly
+#ifndef JPC_API
+#define JPC_API
+#endif
 
 // Always turn on asserts in Debug mode
 #if defined(_DEBUG) || defined(JPH_ENABLE_ASSERTS)
@@ -270,6 +272,13 @@ typedef void (*JPC_FreeFunction)(void *in_block);
 
 typedef void *(*JPC_AlignedAllocateFunction)(size_t in_size, size_t in_alignment);
 typedef void (*JPC_AlignedFreeFunction)(void *in_block);
+
+typedef void (*JPC_TraceFunction)(const char *inFMT, ...);
+typedef bool (*JPC_AssertFailedFunction)(
+    const char* in_expression,
+    const char* in_message,
+    const char* in_file,
+    uint32_t in_line);
 //--------------------------------------------------------------------------------------------------
 //
 // Opaque Types
@@ -906,6 +915,13 @@ JPC_RegisterCustomAllocator(JPC_AllocateFunction in_alloc,
                             JPC_FreeFunction in_free,
                             JPC_AlignedAllocateFunction in_aligned_alloc,
                             JPC_AlignedFreeFunction in_aligned_free);
+
+JPC_API void
+JPC_RegisterTrace(JPC_TraceFunction in_trace);
+
+JPC_API void
+JPC_RegisterAssertFailed(JPC_AssertFailedFunction in_assert_failed);
+
 JPC_API void
 JPC_CreateFactory(void);
 


### PR DESCRIPTION
- Add support for building `joltc` as a shared library
- Add support for setting `Trace` and `AssertFailed` functions
- Add support for exporting / importing the global state, in order to support dll reloading
- Remove `.kfreebsd` as it's no longer present in std

The DLL reloading use case is somewhat niche, so if that isn't something that makes sense here I'm happy to maintain that part in my own fork.

In my project I use a hot-reload approach where the game dll gets reloaded after code changes, so any global state / vtables need to be updated. For context, I made similar changes here: https://github.com/zig-gamedev/zig-gamedev/pull/230
