### PR TITLE
zgui: expose ListClipper API

### DIFF
--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -949,6 +949,38 @@ extern fn zguiDockBuilderFinish(node_id: Ident) void;
 
 //--------------------------------------------------------------------------------------------------
 //
+// ListClipper
+//
+//--------------------------------------------------------------------------------------------------
+pub const ListClipper = extern struct {
+    Ctx: *Context,
+    DisplayStart: c_int,
+    DisplayEnd: c_int,
+    ItemsCount: c_int,
+    ItemsHeight: f32,
+    StartPosY: f32,
+    TempData: *anyopaque,
+
+    pub const init = zguiListClipper_Init;
+    extern fn zguiListClipper_Init() ListClipper;
+
+    pub fn begin(self: *ListClipper, items_count: ?i32, items_height: ?f32) void {
+        zguiListClipper_Begin(self, items_count orelse std.math.maxInt(i32), items_height orelse -1.0);
+    }
+    extern fn zguiListClipper_Begin(self: *ListClipper, items_count: i32, items_height: f32) void;
+
+    pub const end = zguiListClipper_End;
+    extern fn zguiListClipper_End(self: *ListClipper) void;
+
+    pub const includeItemsByIndex = zguiListClipper_IncludeItemsByIndex;
+    extern fn zguiListClipper_IncludeItemsByIndex(self: *ListClipper, item_begin: i32, item_end: i32) void;
+
+    pub const step = zguiListClipper_Step;
+    extern fn zguiListClipper_Step(self: *ListClipper) bool;
+};
+
+//--------------------------------------------------------------------------------------------------
+//
 // Style
 //
 //--------------------------------------------------------------------------------------------------

--- a/libs/zgui/src/zgui.cpp
+++ b/libs/zgui/src/zgui.cpp
@@ -1078,6 +1078,26 @@ ZGUI_API void zguiEndDisabled(void) {
     ImGui::EndDisabled();
 }
 
+ZGUI_API ImGuiListClipper zguiListClipper_Init() {
+    return ImGuiListClipper();
+}
+
+ZGUI_API void zguiListClipper_Begin(ImGuiListClipper *clipper, int items_count, float items_height) {
+    clipper->Begin(items_count, items_height);
+}
+
+ZGUI_API void zguiListClipper_End(ImGuiListClipper *clipper) {
+    clipper->End();
+}
+
+ZGUI_API void zguiListClipper_IncludeItemsByIndex(ImGuiListClipper *clipper, int item_begin, int item_end) {
+    clipper->IncludeItemsByIndex(item_begin, item_end);
+}
+
+ZGUI_API bool zguiListClipper_Step(ImGuiListClipper *clipper) {
+    return clipper->Step();
+}
+
 ZGUI_API ImGuiStyle* zguiGetStyle(void) {
     return &ImGui::GetStyle();
 }


### PR DESCRIPTION
Exposes ImGui's ListClipper to have performant lists/tables with lots of items.

I tested it with my own code, and it works as expected.

Let me know if there is anything missing or that should be changed.