### PR TITLE
zphysics: fixup definition of AABox / JPC_AABox

### DIFF
--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.h
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.h
@@ -595,8 +595,8 @@ typedef struct JPC_RayCastSettings
 // NOTE: Needs to be kept in sync with JPH::AABox
 typedef struct JPC_AABox
 {
-    float min[3];
-    float max[3];
+    float min[4];
+    float max[4];
 } JPC_AABox;
 
 // NOTE: Needs to be kept in sync with JPH::Color

--- a/libs/zphysics/src/zphysics.zig
+++ b/libs/zphysics/src/zphysics.zig
@@ -1135,8 +1135,8 @@ pub const DebugRenderer = if (!debug_renderer_enabled) extern struct {} else ext
     };
 
     pub const AABox = extern struct {
-        min: [3]f32,
-        max: [3]f32,
+        min: [4]f32,
+        max: [4]f32,
     };
 
     pub const LOD = extern struct {


### PR DESCRIPTION
JPH::AABox uses Vec3 which is defined as:

```
 union
 {
  Type     mValue;
  float     mF32[4];
 };
```