### PR TITLE
zgui: Expose Framerate, MetricsWindow and missing TableFlags

### DIFF
--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -278,6 +278,9 @@ pub const io = struct {
     pub const getWantTextInput = zguiIoGetWantTextInput;
     extern fn zguiIoGetWantTextInput() bool;
 
+    pub const getFramerate = zguiIoFramerate;
+    extern fn zguiIoFramerate() f32;
+
     pub fn setIniFilename(filename: ?[*:0]const u8) void {
         zguiIoSetIniFilename(filename);
     }
@@ -637,6 +640,9 @@ extern fn zguiGetDrawData() DrawData;
 /// `pub fn showDemoWindow(popen: ?*bool) void`
 pub const showDemoWindow = zguiShowDemoWindow;
 extern fn zguiShowDemoWindow(popen: ?*bool) void;
+
+pub const showMetricsWindow = zguiShowMetricsWindow;
+extern fn zguiShowMetricsWindow(popen: ?*bool) void;
 //--------------------------------------------------------------------------------------------------
 //
 // Windows
@@ -3073,7 +3079,10 @@ pub const TableFlags = packed struct(c_int) {
     sort_multi: bool = false,
     sort_tristate: bool = false,
 
-    _padding: u4 = 0,
+    // Miscellaneous
+    highlight_hovered_column: bool = false,
+
+    _padding: u3 = 0,
 };
 
 pub const TableRowFlags = packed struct(c_int) {

--- a/libs/zgui/src/zgui.cpp
+++ b/libs/zgui/src/zgui.cpp
@@ -1162,6 +1162,10 @@ extern "C"
         ImGui::ShowDemoWindow(p_open);
     }
 
+    ZGUI_API void zguiShowMetricsWindow(bool* p_open) {
+        ImGui::ShowMetricsWindow(p_open);
+    }
+
     ZGUI_API void zguiBeginDisabled(bool disabled)
     {
         ImGui::BeginDisabled(disabled);
@@ -1499,6 +1503,10 @@ extern "C"
     ZGUI_API bool zguiIoGetWantTextInput(void)
     {
         return ImGui::GetIO().WantTextInput;
+    }
+
+    ZGUI_API float zguiIoFramerate() {
+        return ImGui::GetIO().Framerate;
     }
 
     ZGUI_API void zguiIoSetIniFilename(const char *filename)


### PR DESCRIPTION
Exposes some missing ImGui APIs to monitor performance: `ImGui::GetIO().Framerate`, and `ImGui::ShowMetricsWindow`.

I also added a missing member in the `TableFlags` enum.

Let me know if there is anything missing or that should be changed.