### PR TITLE
zphysics: Exposed Shape.GetLocalBounds and Shape.CastRay

### DIFF
--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
@@ -264,6 +264,21 @@ FN(toJpc)(JPH::CollisionGroup *in) { assert(in); return reinterpret_cast<JPC_Col
 
 FN(toJph)(const JPC_SubShapeID *in) { assert(in); return reinterpret_cast<const JPH::SubShapeID *>(in); }
 
+FN(toJpc)(const JPH::SubShapeIDCreator *in) { assert(in); return reinterpret_cast<const JPC_SubShapeIDCreator *>(in); }
+FN(toJph)(const JPC_SubShapeIDCreator *in) { assert(in); return reinterpret_cast<const JPH::SubShapeIDCreator *>(in); }
+FN(toJpc)(JPH::SubShapeIDCreator *in) { assert(in); return reinterpret_cast<JPC_SubShapeIDCreator *>(in); }
+FN(toJph)(JPC_SubShapeIDCreator *in) { assert(in); return reinterpret_cast<JPH::SubShapeIDCreator *>(in); }
+
+FN(toJpc)(const JPH::RayCast *in) { assert(in); return reinterpret_cast<const JPC_RRayCast *>(in); }
+FN(toJph)(const JPC_RRayCast *in) { assert(in); return reinterpret_cast<const JPH::RayCast *>(in); }
+FN(toJpc)(JPH::RayCast *in) { assert(in); return reinterpret_cast<JPC_RRayCast *>(in); }
+FN(toJph)(JPC_RRayCast *in) { assert(in); return reinterpret_cast<JPH::RayCast *>(in); }
+
+FN(toJpc)(const JPH::RayCastResult *in) { assert(in); return reinterpret_cast<const JPC_RayCastResult *>(in); }
+FN(toJph)(const JPC_RayCastResult *in) { assert(in); return reinterpret_cast<const JPH::RayCastResult *>(in); }
+FN(toJpc)(JPH::RayCastResult *in) { assert(in); return reinterpret_cast<JPC_RayCastResult *>(in); }
+FN(toJph)(JPC_RayCastResult *in) { assert(in); return reinterpret_cast<JPH::RayCastResult *>(in); }
+
 FN(toJph)(const JPC_BodyLockInterface *in) {
     assert(in); return reinterpret_cast<const JPH::BodyLockInterface *>(in);
 }
@@ -1859,6 +1874,23 @@ JPC_API void
 JPC_Shape_GetCenterOfMass(const JPC_Shape *in_shape, JPC_Real out_position[3])
 {
     storeRVec3(out_position, toJph(in_shape)->GetCenterOfMass());
+}
+//--------------------------------------------------------------------------------------------------
+JPC_API JPC_AABox
+JPC_Shape_GetLocalBounds(const JPC_Shape *in_shape)
+{
+    auto bounds = toJph(in_shape)->GetLocalBounds();
+    return *toJpc(&bounds);
+}
+//--------------------------------------------------------------------------------------------------
+JPC_API bool
+JPC_Shape_CastRay(const JPC_Shape *in_shape,
+                  const JPC_RRayCast *in_ray,
+                  const JPC_SubShapeIDCreator *in_id_creator,
+                  JPC_RayCastResult *io_hit)
+{
+    assert(in_shape && in_ray && in_id_creator && io_hit);
+    return toJph(in_shape)->CastRay(*toJph(in_ray), *toJph(in_id_creator), *toJph(io_hit));
 }
 //--------------------------------------------------------------------------------------------------
 //

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.h
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.h
@@ -591,13 +591,14 @@ typedef struct JPC_RayCastSettings
     bool             treat_convex_as_solid;
 } JPC_RayCastSettings;
 
-#if JPC_DEBUG_RENDERER == 1
-// NOTE: Needs to be kept in sync with JPH::AABox
 typedef struct JPC_AABox
 {
-    float min[4];
-    float max[4];
+    JPC_RVEC_ALIGN JPC_Real min[3];
+    JPC_RVEC_ALIGN JPC_Real max[3];
 } JPC_AABox;
+
+#if JPC_DEBUG_RENDERER == 1
+// NOTE: Needs to be kept in sync with JPH::AABox
 
 // NOTE: Needs to be kept in sync with JPH::Color
 typedef union JPC_Color
@@ -1599,6 +1600,15 @@ JPC_Shape_SetUserData(JPC_Shape *in_shape, uint64_t in_user_data);
 
 JPC_API void
 JPC_Shape_GetCenterOfMass(const JPC_Shape *in_shape, JPC_Real out_position[3]);
+
+JPC_API JPC_AABox
+JPC_Shape_GetLocalBounds(const JPC_Shape *in_shape);
+
+JPC_API bool
+JPC_Shape_CastRay(const JPC_Shape *in_shape,
+                  const JPC_RRayCast *in_ray,
+                  const JPC_SubShapeIDCreator *in_id_creator,
+                  JPC_RayCastResult *io_hit); // *Must* be default initialized (see JPC_RayCastResult)
 //--------------------------------------------------------------------------------------------------
 //
 // JPC_ConvexHullShape

--- a/samples/monolith/src/monolith.zig
+++ b/samples/monolith/src/monolith.zig
@@ -542,7 +542,7 @@ const DebugRenderer = struct {
     fn drawGeometry(
         self: *DebugRenderer,
         model_matrix: *const [16]zphy.Real,
-        _: *const zphy.DebugRenderer.AABox,
+        _: *const zphy.AABox,
         _: f32,
         color: zphy.DebugRenderer.Color,
         geometry: *const zphy.DebugRenderer.Geometry,


### PR DESCRIPTION
Also moved DebugRenderer.AABox to simply AABox, since it should have been independent anyway to reflect Jolt's architecture, and needs to be used for GetLocalBounds.

AABox also should have been using Reals instead of floats, so that is also fixed.