### PR TITLE
zglfw: Add glfw.setErrorCallback

### DIFF
--- a/libs/zglfw/src/zglfw.zig
+++ b/libs/zglfw/src/zglfw.zig
@@ -125,6 +125,14 @@ pub fn maybeErrorString(str: *?[:0]const u8) Error!void {
 }
 extern fn glfwGetError(description: ?*?[*:0]const u8) i32;
 
+/// `pub fn setErrorCallback(callback: ?ErrorFn) ?ErrorFn`
+pub const setErrorCallback = glfwSetErrorCallback;
+extern fn glfwSetErrorCallback(callback: ?ErrorFn) ?ErrorFn;
+pub const ErrorFn = *const fn (
+    error_code: i32,
+    description: *?[:0]const u8,
+) callconv(.C) void;
+
 pub const InputMode = enum(i32) {
     cursor = 0x00033001,
     sticky_keys = 0x00033002,


### PR DESCRIPTION
Adds a binding for the `glfwSetErrorCallback` function.

Closes #621.