### PR TITLE
zphysics: Expose Shape.GetSurfaceNormal and Shape.GetSupportingFace

### DIFF
--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
@@ -1893,6 +1893,22 @@ JPC_Shape_GetSurfaceNormal(const JPC_Shape *in_shape,
     storeVec3(out_normal, toJph(in_shape)->GetSurfaceNormal(*toJph(&in_sub_shape_id), loadVec3(in_point)));
 }
 //--------------------------------------------------------------------------------------------------
+JPC_API JPC_Shape_SupportingFace
+JPC_Shape_GetSupportingFace(const JPC_Shape *in_shape,
+                            JPC_SubShapeID in_sub_shape_id,
+                            const float in_direction[3],
+                            const float in_scale[3],
+                            const float in_transform[16])
+{
+    auto face = JPH::Shape::SupportingFace();
+    toJph(in_shape)->GetSupportingFace(*toJph(&in_sub_shape_id),
+                                       loadVec3(in_direction),
+                                       loadVec3(in_scale),
+                                       loadMat44(in_transform),
+                                       face);
+    return *reinterpret_cast<JPC_Shape_SupportingFace*>(&face);
+}
+//--------------------------------------------------------------------------------------------------
 JPC_API bool
 JPC_Shape_CastRay(const JPC_Shape *in_shape,
                   const JPC_RRayCast *in_ray,

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
@@ -1883,6 +1883,16 @@ JPC_Shape_GetLocalBounds(const JPC_Shape *in_shape)
     return *toJpc(&bounds);
 }
 //--------------------------------------------------------------------------------------------------
+JPC_API void
+JPC_Shape_GetSurfaceNormal(const JPC_Shape *in_shape,
+                           JPC_SubShapeID in_sub_shape_id,
+                           const float in_point[3],
+                           float out_normal[3])
+{
+    auto subShapeId = *toJph(&in_sub_shape_id);
+    storeVec3(out_normal, toJph(in_shape)->GetSurfaceNormal(*toJph(&in_sub_shape_id), loadVec3(in_point)));
+}
+//--------------------------------------------------------------------------------------------------
 JPC_API bool
 JPC_Shape_CastRay(const JPC_Shape *in_shape,
                   const JPC_RRayCast *in_ray,
@@ -3138,3 +3148,4 @@ JPC_CharacterVirtual_SetLinearVelocity(JPC_CharacterVirtual *in_character, const
 {
     toJph(in_character)->SetLinearVelocity(loadVec3(in_linear_velocity));
 }
+//--------------------------------------------------------------------------------------------------

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.h
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.h
@@ -597,6 +597,12 @@ typedef struct JPC_AABox
     JPC_RVEC_ALIGN JPC_Real max[3];
 } JPC_AABox;
 
+typedef struct JPC_Shape_SupportingFace
+{
+    alignas(16) uint32_t num_points;
+    alignas(16) float    points[32][4]; // 4th element is ignored; world space
+} JPC_Shape_SupportingFace;
+
 #if JPC_DEBUG_RENDERER == 1
 // NOTE: Needs to be kept in sync with JPH::AABox
 
@@ -1609,6 +1615,13 @@ JPC_Shape_GetSurfaceNormal(const JPC_Shape *in_shape,
                            JPC_SubShapeID in_sub_shape_id,
                            const float in_point[3],
                            float out_normal[3]);
+
+JPC_API JPC_Shape_SupportingFace
+JPC_Shape_GetSupportingFace(const JPC_Shape *in_shape,
+                            JPC_SubShapeID in_sub_shape_id,
+                            const float in_direction[3],
+                            const float in_scale[3],
+                            const float in_transform[16]);
 
 JPC_API bool
 JPC_Shape_CastRay(const JPC_Shape *in_shape,

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.h
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.h
@@ -1604,6 +1604,12 @@ JPC_Shape_GetCenterOfMass(const JPC_Shape *in_shape, JPC_Real out_position[3]);
 JPC_API JPC_AABox
 JPC_Shape_GetLocalBounds(const JPC_Shape *in_shape);
 
+JPC_API void
+JPC_Shape_GetSurfaceNormal(const JPC_Shape *in_shape,
+                           JPC_SubShapeID in_sub_shape_id,
+                           const float in_point[3],
+                           float out_normal[3]);
+
 JPC_API bool
 JPC_Shape_CastRay(const JPC_Shape *in_shape,
                   const JPC_RRayCast *in_ray,

--- a/libs/zphysics/src/zphysics.zig
+++ b/libs/zphysics/src/zphysics.zig
@@ -665,8 +665,8 @@ pub const SubShapeIdPair = extern struct {
 };
 
 pub const SubShapeIDCreator = extern struct {
-    id: SubShapeId = @import("std").mem.zeroes(SubShapeId),
-    current_bit: u32 = @import("std").mem.zeroes(u32),
+    id: SubShapeId = sub_shape_id_empty,
+    current_bit: u32 = 0,
 
     comptime {
         assert(@sizeOf(SubShapeIDCreator) == @sizeOf(c.JPC_SubShapeIDCreator));
@@ -3244,6 +3244,17 @@ pub const Shape = opaque {
             pub fn getLocalBounds(shape: *const T) AABox {
                 const aabox = c.JPC_Shape_GetLocalBounds(@as(*const c.JPC_Shape, @ptrCast(shape)));
                 return @as(*AABox, @constCast(@ptrCast(&aabox))).*;
+            }
+
+            pub fn getSurfaceNormal(shape: *const T, sub_shape_id: SubShapeId, local_pos: [3]f32) [3]f32 {
+                var normal: [3]f32 = undefined;
+                c.JPC_Shape_GetSurfaceNormal(
+                    @as(*const c.JPC_Shape, @ptrCast(shape)),
+                    sub_shape_id,
+                    &local_pos,
+                    &normal,
+                );
+                return normal;
             }
 
             pub fn castRay(

--- a/libs/zphysics/src/zphysics.zig
+++ b/libs/zphysics/src/zphysics.zig
@@ -3196,6 +3196,16 @@ pub const Shape = opaque {
         user_convex8 = c.JPC_SHAPE_SUB_TYPE_USER_CONVEX8,
     };
 
+    pub const SupportingFace = extern struct {
+        num_points: u32 align(16),
+        points: [32][4]f32 align(16), // 4th element is ignored; world space
+
+        comptime {
+            assert(@sizeOf(SupportingFace) == @sizeOf(c.JPC_Shape_SupportingFace));
+            assert(@offsetOf(SupportingFace, "points") == @offsetOf(c.JPC_Shape_SupportingFace, "points"));
+        }
+    };
+
     fn Methods(comptime T: type) type {
         return struct {
             pub fn asShape(shape: *const T) *const Shape {
@@ -3255,6 +3265,23 @@ pub const Shape = opaque {
                     &normal,
                 );
                 return normal;
+            }
+
+            pub fn getSupportingFace(
+                shape: *const T,
+                sub_shape_id: SubShapeId,
+                direction: [3]f32,
+                shape_scale: [3]f32,
+                com_transform: [16]f32,
+            ) SupportingFace {
+                const c_face = c.JPC_Shape_GetSupportingFace(
+                    @as(*const c.JPC_Shape, @ptrCast(shape)),
+                    sub_shape_id,
+                    &direction,
+                    &shape_scale,
+                    &com_transform,
+                );
+                return @as(*const SupportingFace, @ptrCast(&c_face)).*;
             }
 
             pub fn castRay(


### PR DESCRIPTION
Also fixes an error made in the zig version of the SubShapeIDCreator struct.