### PR TITLE
zgui doesn't cover imgui API, missing drag functionality

### DIFF
--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -3266,8 +3266,12 @@ pub const MouseButton = enum(u32) {
 pub const isMouseDown = zguiIsMouseDown;
 /// `pub fn isMouseClicked(mouse_button: MouseButton) bool`
 pub const isMouseClicked = zguiIsMouseClicked;
+/// `pub fn isMouseReleased(mouse_button: MouseButton) bool`
+pub const isMouseReleased = zguiIsMouseReleased;
 /// `pub fn isMouseDoubleClicked(mouse_button: MouseButton) bool`
 pub const isMouseDoubleClicked = zguiIsMouseDoubleClicked;
+/// `pub fn getMouseClickedCount(mouse_button: MouseButton) bool`
+pub const getMouseClickedCount = zguiGetMouseClickedCount;
 /// `pub fn isMouseDragging(mouse_button: MouseButton, lock_threshold: f32) bool`
 pub const isMouseDragging = zguiIsMouseDragging;
 /// `pub fn isItemClicked(mouse_button: MouseButton) bool`
@@ -3292,7 +3296,9 @@ pub const isAnyItemActive = zguiIsAnyItemActive;
 pub const isAnyItemFocused = zguiIsAnyItemFocused;
 extern fn zguiIsMouseDown(mouse_button: MouseButton) bool;
 extern fn zguiIsMouseClicked(mouse_button: MouseButton) bool;
+extern fn zguiIsMouseReleased(mouse_button: MouseButton) bool;
 extern fn zguiIsMouseDoubleClicked(mouse_button: MouseButton) bool;
+extern fn zguiGetMouseClickedCount(mouse_button: MouseButton) u32;
 extern fn zguiIsMouseDragging(mouse_button: MouseButton, lock_threshold: f32) bool;
 extern fn zguiIsItemHovered(flags: HoveredFlags) bool;
 extern fn zguiIsItemActive() bool;

--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -3268,6 +3268,8 @@ pub const isMouseDown = zguiIsMouseDown;
 pub const isMouseClicked = zguiIsMouseClicked;
 /// `pub fn isMouseDoubleClicked(mouse_button: MouseButton) bool`
 pub const isMouseDoubleClicked = zguiIsMouseDoubleClicked;
+/// `pub fn isMouseDragging(mouse_button: MouseButton, lock_threshold: f32) bool`
+pub const isMouseDragging = zguiIsMouseDragging;
 /// `pub fn isItemClicked(mouse_button: MouseButton) bool`
 pub const isItemClicked = zguiIsItemClicked;
 /// `pub fn isItemVisible() bool`
@@ -3291,6 +3293,7 @@ pub const isAnyItemFocused = zguiIsAnyItemFocused;
 extern fn zguiIsMouseDown(mouse_button: MouseButton) bool;
 extern fn zguiIsMouseClicked(mouse_button: MouseButton) bool;
 extern fn zguiIsMouseDoubleClicked(mouse_button: MouseButton) bool;
+extern fn zguiIsMouseDragging(mouse_button: MouseButton, lock_threshold: f32) bool;
 extern fn zguiIsItemHovered(flags: HoveredFlags) bool;
 extern fn zguiIsItemActive() bool;
 extern fn zguiIsItemFocused() bool;

--- a/libs/zgui/src/zgui.cpp
+++ b/libs/zgui/src/zgui.cpp
@@ -1616,6 +1616,11 @@ extern "C"
         return ImGui::IsMouseDoubleClicked(button);
     }
 
+    ZGUI_API bool zguiIsMouseDragging(ImGuiMouseButton button, float lock_threshold)
+    {
+        return ImGui::IsMouseDoubleClicked(button);
+    }
+
     ZGUI_API bool zguiIsItemVisible(void)
     {
         return ImGui::IsItemVisible();

--- a/libs/zgui/src/zgui.cpp
+++ b/libs/zgui/src/zgui.cpp
@@ -1628,7 +1628,7 @@ extern "C"
 
     ZGUI_API bool zguiIsMouseDragging(ImGuiMouseButton button, float lock_threshold)
     {
-        return ImGui::IsMouseDoubleClicked(button);
+        return ImGui::IsMouseDragging(button, lock_threshold);
     }
 
     ZGUI_API bool zguiIsItemVisible(void)

--- a/libs/zgui/src/zgui.cpp
+++ b/libs/zgui/src/zgui.cpp
@@ -1611,9 +1611,19 @@ extern "C"
         return ImGui::IsMouseClicked(button);
     }
 
+    ZGUI_API bool zguiIsMouseReleased(ImGuiMouseButton button)
+    {
+        return ImGui::IsMouseReleased(button);
+    }
+
     ZGUI_API bool zguiIsMouseDoubleClicked(ImGuiMouseButton button)
     {
         return ImGui::IsMouseDoubleClicked(button);
+    }
+
+    ZGUI_API int zguiGetMouseClickedCount(ImGuiMouseButton button)
+    {
+        return ImGui::GetMouseClickedCount(button);
     }
 
     ZGUI_API bool zguiIsMouseDragging(ImGuiMouseButton button, float lock_threshold)


### PR DESCRIPTION
I was porting another application using Imgui and realized IsMouseDragging() was missing. 

Since the bindings are hand written I'm wondering if there's other discrepancies. I fixed some others I need for now. Also there's overloads which aren't added.

We should consider non hand written in the future for robustness.

I don't know is it's okay to do this, but I changed the return type from MouseClickedCount to u32 since the value doesn't go below 0.