### PR TITLE
[zgpu] Fix definition of CompilationInfoCallback to match libdawn

### DIFF
--- a/libs/zgpu/src/wgpu.zig
+++ b/libs/zgpu/src/wgpu.zig
@@ -1241,6 +1241,7 @@ pub const QueueWorkDoneCallback = *const fn (
 
 pub const CompilationInfoCallback = *const fn (
     status: CompilationInfoRequestStatus,
+    info: *const CompilationInfo,
     userdata: ?*anyopaque,
 ) callconv(.C) void;
 


### PR DESCRIPTION
Fixes zig-gamedev/zig-gamedev#697