### PR TITLE
zphysics: Fixed types for double precision support

### DIFF
--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
@@ -1727,10 +1727,10 @@ JPC_MeshShapeSettings_Sanitize(JPC_MeshShapeSettings *in_settings)
 //--------------------------------------------------------------------------------------------------
 JPC_API JPC_DecoratedShapeSettings *
 JPC_RotatedTranslatedShapeSettings_Create(const JPC_ShapeSettings *in_inner_shape_settings,
-                                          const JPC_Real in_rotated[4],
-                                          const JPC_Real in_translated[3])
+                                          const float in_rotated[4],
+                                          const float in_translated[3])
 {
-    auto settings = new JPH::RotatedTranslatedShapeSettings(loadRVec3(in_translated),
+    auto settings = new JPH::RotatedTranslatedShapeSettings(loadVec3(in_translated),
                                                             JPH::Quat(loadVec4(in_rotated)),
                                                             toJph(in_inner_shape_settings));
     settings->AddRef();
@@ -1739,18 +1739,18 @@ JPC_RotatedTranslatedShapeSettings_Create(const JPC_ShapeSettings *in_inner_shap
 //--------------------------------------------------------------------------------------------------
 JPC_API JPC_DecoratedShapeSettings *
 JPC_ScaledShapeSettings_Create(const JPC_ShapeSettings *in_inner_shape_settings,
-                               const JPC_Real in_scale[3])
+                               const float in_scale[3])
 {
-    auto settings = new JPH::ScaledShapeSettings(toJph(in_inner_shape_settings), loadRVec3(in_scale));
+    auto settings = new JPH::ScaledShapeSettings(toJph(in_inner_shape_settings), loadVec3(in_scale));
     settings->AddRef();
     return toJpc(settings);
 }
 //--------------------------------------------------------------------------------------------------
 JPC_API JPC_DecoratedShapeSettings *
 JPC_OffsetCenterOfMassShapeSettings_Create(const JPC_ShapeSettings *in_inner_shape_settings,
-                                           const JPC_Real in_center_of_mass[3])
+                                           const float in_center_of_mass[3])
 {
-    auto settings = new JPH::OffsetCenterOfMassShapeSettings(loadRVec3(in_center_of_mass),
+    auto settings = new JPH::OffsetCenterOfMassShapeSettings(loadVec3(in_center_of_mass),
                                                              toJph(in_inner_shape_settings));
     settings->AddRef();
     return toJpc(settings);
@@ -1778,12 +1778,12 @@ JPC_MutableCompoundShapeSettings_Create()
 //--------------------------------------------------------------------------------------------------
 JPC_API void
 JPC_CompoundShapeSettings_AddShape(JPC_CompoundShapeSettings *in_settings,
-                                   const JPC_Real in_position[3],
-                                   const JPC_Real in_rotation[4],
+                                   const float in_position[3],
+                                   const float in_rotation[4],
                                    const JPC_ShapeSettings *in_shape,
                                    const uint32_t in_user_data)
 {
-    toJph(in_settings)->AddShape(loadRVec3(in_position),
+    toJph(in_settings)->AddShape(loadVec3(in_position),
                                  JPH::Quat(loadVec4(in_rotation)),
                                  toJph(in_shape),
                                  in_user_data);
@@ -1882,9 +1882,9 @@ JPC_Shape_GetVolume(const JPC_Shape *in_shape)
 }
 //--------------------------------------------------------------------------------------------------
 JPC_API void
-JPC_Shape_GetCenterOfMass(const JPC_Shape *in_shape, JPC_Real out_position[3])
+JPC_Shape_GetCenterOfMass(const JPC_Shape *in_shape, float out_position[3])
 {
-    storeRVec3(out_position, toJph(in_shape)->GetCenterOfMass());
+    storeVec3(out_position, toJph(in_shape)->GetCenterOfMass());
 }
 //--------------------------------------------------------------------------------------------------
 JPC_API JPC_AABox
@@ -2255,7 +2255,7 @@ JPC_BodyInterface_GetCenterOfMassPosition(const JPC_BodyInterface *in_iface,
 JPC_API void
 JPC_BodyInterface_SetRotation(JPC_BodyInterface *in_iface,
                               JPC_BodyID in_body_id,
-                              const JPC_Real in_rotation[4],
+                              const float in_rotation[4],
                               JPC_Activation in_activation)
 {
     toJph(in_iface)->SetRotation(toJph(in_body_id), JPH::Quat(loadVec4(in_rotation)), static_cast<JPH::EActivation>(in_activation));
@@ -3007,7 +3007,7 @@ JPC_Character_Create(const JPC_CharacterSettings *in_settings,
                      JPC_PhysicsSystem *in_physics_system)
 {
     auto character = new JPH::Character(toJph(in_settings),
-                                        loadVec3(in_position),
+                                        loadRVec3(in_position),
                                         JPH::Quat(loadVec4(in_rotation)),
                                         in_user_data,
                                         toJph(in_physics_system));
@@ -3085,7 +3085,7 @@ JPC_CharacterVirtual_Create(const JPC_CharacterVirtualSettings *in_settings,
                             JPC_PhysicsSystem *in_physics_system)
 {
     auto character = new JPH::CharacterVirtual(
-        toJph(in_settings), loadVec3(in_position), JPH::Quat(loadVec4(in_rotation)), toJph(in_physics_system));
+        toJph(in_settings), loadRVec3(in_position), JPH::Quat(loadVec4(in_rotation)), toJph(in_physics_system));
     return toJpc(character);
 }
 //--------------------------------------------------------------------------------------------------

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
@@ -29,6 +29,7 @@
 #include <Jolt/Physics/Collision/Shape/StaticCompoundShape.h>
 #include <Jolt/Physics/Collision/Shape/MutableCompoundShape.h>
 #include <Jolt/Physics/Collision/PhysicsMaterial.h>
+#include <Jolt/Physics/Collision/RayCast.h>
 #include <Jolt/Physics/Constraints/FixedConstraint.h>
 #include <Jolt/Physics/Body/BodyCreationSettings.h>
 #include <Jolt/Physics/Body/BodyActivationListener.h>
@@ -274,10 +275,15 @@ FN(toJph)(const JPC_SubShapeIDCreator *in) { assert(in); return reinterpret_cast
 FN(toJpc)(JPH::SubShapeIDCreator *in) { assert(in); return reinterpret_cast<JPC_SubShapeIDCreator *>(in); }
 FN(toJph)(JPC_SubShapeIDCreator *in) { assert(in); return reinterpret_cast<JPH::SubShapeIDCreator *>(in); }
 
-FN(toJpc)(const JPH::RayCast *in) { assert(in); return reinterpret_cast<const JPC_RRayCast *>(in); }
-FN(toJph)(const JPC_RRayCast *in) { assert(in); return reinterpret_cast<const JPH::RayCast *>(in); }
-FN(toJpc)(JPH::RayCast *in) { assert(in); return reinterpret_cast<JPC_RRayCast *>(in); }
-FN(toJph)(JPC_RRayCast *in) { assert(in); return reinterpret_cast<JPH::RayCast *>(in); }
+FN(toJpc)(const JPH::RayCast *in) { assert(in); return reinterpret_cast<const JPC_RayCast *>(in); }
+FN(toJph)(const JPC_RayCast *in) { assert(in); return reinterpret_cast<const JPH::RayCast *>(in); }
+FN(toJpc)(JPH::RayCast *in) { assert(in); return reinterpret_cast<JPC_RayCast *>(in); }
+FN(toJph)(JPC_RayCast *in) { assert(in); return reinterpret_cast<JPH::RayCast *>(in); }
+
+FN(toJpc)(const JPH::RRayCast *in) { assert(in); return reinterpret_cast<const JPC_RRayCast *>(in); }
+FN(toJph)(const JPC_RRayCast *in) { assert(in); return reinterpret_cast<const JPH::RRayCast *>(in); }
+FN(toJpc)(JPH::RRayCast *in) { assert(in); return reinterpret_cast<JPC_RRayCast *>(in); }
+FN(toJph)(JPC_RRayCast *in) { assert(in); return reinterpret_cast<JPH::RRayCast *>(in); }
 
 FN(toJpc)(const JPH::RayCastResult *in) { assert(in); return reinterpret_cast<const JPC_RayCastResult *>(in); }
 FN(toJph)(const JPC_RayCastResult *in) { assert(in); return reinterpret_cast<const JPH::RayCastResult *>(in); }
@@ -1922,7 +1928,7 @@ JPC_Shape_GetSupportingFace(const JPC_Shape *in_shape,
 //--------------------------------------------------------------------------------------------------
 JPC_API bool
 JPC_Shape_CastRay(const JPC_Shape *in_shape,
-                  const JPC_RRayCast *in_ray,
+                  const JPC_RayCast *in_ray,
                   const JPC_SubShapeIDCreator *in_id_creator,
                   JPC_RayCastResult *io_hit)
 {

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.h
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.h
@@ -1528,16 +1528,16 @@ JPC_MeshShapeSettings_Sanitize(JPC_MeshShapeSettings *in_settings);
 //--------------------------------------------------------------------------------------------------
 JPC_API JPC_DecoratedShapeSettings *
 JPC_RotatedTranslatedShapeSettings_Create(const JPC_ShapeSettings *in_inner_shape_settings,
-                                          const JPC_Real in_rotated[4],
-                                          const JPC_Real in_translated[3]);
+                                          const float in_rotated[4],
+                                          const float in_translated[3]);
 
 JPC_API JPC_DecoratedShapeSettings *
 JPC_ScaledShapeSettings_Create(const JPC_ShapeSettings *in_inner_shape_settings,
-                               const JPC_Real in_scale[3]);
+                               const float in_scale[3]);
 
 JPC_API JPC_DecoratedShapeSettings *
 JPC_OffsetCenterOfMassShapeSettings_Create(const JPC_ShapeSettings *in_inner_shape_settings,
-                                           const JPC_Real in_center_of_mass[3]);
+                                           const float in_center_of_mass[3]);
 //--------------------------------------------------------------------------------------------------
 //
 // JPC_CompoundShapeSettings (-> JPC_ShapeSettings)
@@ -1551,8 +1551,8 @@ JPC_MutableCompoundShapeSettings_Create();
 
 JPC_API void
 JPC_CompoundShapeSettings_AddShape(JPC_CompoundShapeSettings *in_settings,
-                                   const JPC_Real in_position[3],
-                                   const JPC_Real in_rotation[4],
+                                   const float in_position[3],
+                                   const float in_rotation[4],
                                    const JPC_ShapeSettings *in_shape,
                                    const uint32_t in_user_data);
 //--------------------------------------------------------------------------------------------------
@@ -1609,7 +1609,7 @@ JPC_API float
 JPC_Shape_GetVolume(const JPC_Shape *in_shape);
 
 JPC_API void
-JPC_Shape_GetCenterOfMass(const JPC_Shape *in_shape, JPC_Real out_position[3]);
+JPC_Shape_GetCenterOfMass(const JPC_Shape *in_shape, float out_position[3]);
 
 JPC_API JPC_AABox
 JPC_Shape_GetLocalBounds(const JPC_Shape *in_shape);
@@ -1817,7 +1817,7 @@ JPC_BodyInterface_GetRotation(const JPC_BodyInterface *in_iface,
 JPC_API void
 JPC_BodyInterface_SetRotation(JPC_BodyInterface *in_iface,
                               JPC_BodyID in_body_id,
-                              const JPC_Real in_rotation[4],
+                              const float in_rotation[4],
                               JPC_Activation in_activation);
 JPC_API void
 JPC_BodyInterface_ActivateBody(JPC_BodyInterface *in_iface, JPC_BodyID in_body_id);

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.h
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.h
@@ -570,6 +570,13 @@ typedef struct JPC_BodyLockWrite
     JPC_Body *                   body;
 } JPC_BodyLockWrite;
 
+// NOTE: Needs to be kept in sync with JPH::RayCast
+typedef struct JPC_RayCast
+{
+    alignas(16) float origin[4]; // 4th element is ignored
+    alignas(16) float direction[4]; // length of the vector is important; 4th element is ignored
+} JPC_RayCast;
+
 // NOTE: Needs to be kept in sync with JPH::RRayCast
 typedef struct JPC_RRayCast
 {
@@ -594,8 +601,8 @@ typedef struct JPC_RayCastSettings
 
 typedef struct JPC_AABox
 {
-    JPC_RVEC_ALIGN JPC_Real min[3];
-    JPC_RVEC_ALIGN JPC_Real max[3];
+    alignas(16) float min[3];
+    alignas(16) float max[3];
 } JPC_AABox;
 
 typedef struct JPC_Shape_SupportingFace
@@ -1629,7 +1636,7 @@ JPC_Shape_GetSupportingFace(const JPC_Shape *in_shape,
 
 JPC_API bool
 JPC_Shape_CastRay(const JPC_Shape *in_shape,
-                  const JPC_RRayCast *in_ray,
+                  const JPC_RayCast *in_ray,
                   const JPC_SubShapeIDCreator *in_id_creator,
                   JPC_RayCastResult *io_hit); // *Must* be default initialized (see JPC_RayCastResult)
 //--------------------------------------------------------------------------------------------------

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC_Extensions.cpp
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC_Extensions.cpp
@@ -144,6 +144,7 @@ ENSURE_SIZE_ALIGN(JPH::Body,                 JPC_Body)
 ENSURE_SIZE_ALIGN(JPH::BodyLockRead,  JPC_BodyLockRead)
 ENSURE_SIZE_ALIGN(JPH::BodyLockWrite, JPC_BodyLockWrite)
 
+ENSURE_SIZE_ALIGN(JPH::RayCast, JPC_RayCast)
 ENSURE_SIZE_ALIGN(JPH::RRayCast, JPC_RRayCast)
 ENSURE_SIZE_ALIGN(JPH::RayCastResult, JPC_RayCastResult)
 ENSURE_SIZE_ALIGN(JPH::RayCastSettings, JPC_RayCastSettings)

--- a/libs/zphysics/src/zphysics.zig
+++ b/libs/zphysics/src/zphysics.zig
@@ -4143,11 +4143,11 @@ test "zphysics.body.basic" {
     const floor_shape = try floor_shape_settings.createShape();
     defer floor_shape.release();
 
-    var shape_ray = RayCast { .origin = .{ 0, 2, 0, 1 }, .direction = .{ 101, -1, 0, 0 } };
+    var shape_ray = RayCast{ .origin = .{ 0, 2, 0, 1 }, .direction = .{ 101, -1, 0, 0 } };
     var shape_result = floor_shape.castRay(shape_ray, .{});
     try expect(shape_result.has_hit == false);
 
-    shape_ray = RayCast { .origin = .{ 0, 2, 0, 1 }, .direction = .{ 100, -1, 0, 0 } };
+    shape_ray = RayCast{ .origin = .{ 0, 2, 0, 1 }, .direction = .{ 100, -1, 0, 0 } };
     shape_result = floor_shape.castRay(shape_ray, .{});
     try expect(shape_result.has_hit == true);
 

--- a/libs/zphysics/src/zphysics.zig
+++ b/libs/zphysics/src/zphysics.zig
@@ -1806,7 +1806,7 @@ pub const BodyInterface = opaque {
         return rotation;
     }
 
-    pub fn setRotation(body_iface: *BodyInterface, body_id: BodyId, in_rotation: [4]Real, in_activation_type: Activation) void {
+    pub fn setRotation(body_iface: *BodyInterface, body_id: BodyId, in_rotation: [4]f32, in_activation_type: Activation) void {
         c.JPC_BodyInterface_SetRotation(@as(*c.JPC_BodyInterface, @ptrCast(body_iface)), body_id, &in_rotation, @intFromEnum(in_activation_type));
     }
 
@@ -3083,8 +3083,8 @@ pub const DecoratedShapeSettings = opaque {
 
     pub fn createRotatedTranslated(
         inner_shape: *const ShapeSettings,
-        rotation: [4]Real,
-        translation: [3]Real,
+        rotation: [4]f32,
+        translation: [3]f32,
     ) !*DecoratedShapeSettings {
         const settings = c.JPC_RotatedTranslatedShapeSettings_Create(
             @as(*const c.JPC_ShapeSettings, @ptrCast(inner_shape)),
@@ -3095,7 +3095,7 @@ pub const DecoratedShapeSettings = opaque {
         return @as(*DecoratedShapeSettings, @ptrCast(settings));
     }
 
-    pub fn createScaled(inner_shape: *const ShapeSettings, scale: [3]Real) !*DecoratedShapeSettings {
+    pub fn createScaled(inner_shape: *const ShapeSettings, scale: [3]f32) !*DecoratedShapeSettings {
         const settings = c.JPC_ScaledShapeSettings_Create(
             @as(*const c.JPC_ShapeSettings, @ptrCast(inner_shape)),
             &scale,
@@ -3104,7 +3104,7 @@ pub const DecoratedShapeSettings = opaque {
         return @as(*DecoratedShapeSettings, @ptrCast(settings));
     }
 
-    pub fn createOffsetCenterOfMass(inner_shape: *const ShapeSettings, offset: [3]Real) !*DecoratedShapeSettings {
+    pub fn createOffsetCenterOfMass(inner_shape: *const ShapeSettings, offset: [3]f32) !*DecoratedShapeSettings {
         const settings = c.JPC_OffsetCenterOfMassShapeSettings_Create(
             @as(*const c.JPC_ShapeSettings, @ptrCast(inner_shape)),
             &offset,
@@ -3133,7 +3133,7 @@ pub const CompoundShapeSettings = opaque {
         return @as(*CompoundShapeSettings, @ptrCast(settings));
     }
 
-    pub fn addShape(settings: *CompoundShapeSettings, position: [3]Real, rotation: [4]Real, shape: *const ShapeSettings, user_data: u32) void {
+    pub fn addShape(settings: *CompoundShapeSettings, position: [3]f32, rotation: [4]f32, shape: *const ShapeSettings, user_data: u32) void {
         c.JPC_CompoundShapeSettings_AddShape(
             @as(*c.JPC_CompoundShapeSettings, @ptrCast(settings)),
             &position,
@@ -3249,8 +3249,8 @@ pub const Shape = opaque {
                 return c.JPC_Shape_GetVolume(@as(*const c.JPC_Shape, @ptrCast(shape)));
             }
 
-            pub fn getCenterOfMass(shape: *const T) [3]Real {
-                var center: [3]Real = undefined;
+            pub fn getCenterOfMass(shape: *const T) [3]f32 {
+                var center: [3]f32 = undefined;
                 c.JPC_Shape_GetCenterOfMass(@as(*const c.JPC_Shape, @ptrCast(shape)), &center);
                 return center;
             }


### PR DESCRIPTION
All tests should now pass with both single and double-precision floats set in Jolt.