### PR TITLE
zgui: add ImGui default colors style API

### DIFF
--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -1062,6 +1062,22 @@ pub const Style = extern struct {
     pub const scaleAllSizes = zguiStyle_ScaleAllSizes;
     extern fn zguiStyle_ScaleAllSizes(style: *Style, scale_factor: f32) void;
 
+    pub const DefaultColors = enum {
+        dark,
+        light,
+        classic,
+    };
+    pub fn setDefaultColors(style: *Style, variant: DefaultColors) void {
+        switch (variant) {
+            .dark => zguiStyleColorsDark(style),
+            .light => zguiStyleColorsLight(style),
+            .classic => zguiStyleColorsClassic(style),
+        }
+    }
+    extern fn zguiStyleColorsDark(style: *Style) void;
+    extern fn zguiStyleColorsLight(style: *Style) void;
+    extern fn zguiStyleColorsClassic(style: *Style) void;
+
     pub fn getColor(style: Style, idx: StyleCol) [4]f32 {
         return style.colors[@intCast(@intFromEnum(idx))];
     }

--- a/libs/zgui/src/gui.zig
+++ b/libs/zgui/src/gui.zig
@@ -1062,21 +1062,27 @@ pub const Style = extern struct {
     pub const scaleAllSizes = zguiStyle_ScaleAllSizes;
     extern fn zguiStyle_ScaleAllSizes(style: *Style, scale_factor: f32) void;
 
-    pub const DefaultColors = enum {
+    /// `pub fn styleColorsDark(*Style)`
+    pub const setColorsDark = zguiStyleColorsDark;
+
+    /// `pub fn styleColorsLight(*Style)`
+    pub const setColorsLight = zguiStyleColorsLight;
+
+    /// `pub fn styleColorsClassic(*Style)`
+    pub const setColorsClassic = zguiStyleColorsClassic;
+
+    pub const StyleColorsBuiltin = enum {
         dark,
         light,
         classic,
     };
-    pub fn setDefaultColors(style: *Style, variant: DefaultColors) void {
+    pub fn setColorsBuiltin(style: *Style, variant: StyleColorsBuiltin) void {
         switch (variant) {
             .dark => zguiStyleColorsDark(style),
             .light => zguiStyleColorsLight(style),
             .classic => zguiStyleColorsClassic(style),
         }
     }
-    extern fn zguiStyleColorsDark(style: *Style) void;
-    extern fn zguiStyleColorsLight(style: *Style) void;
-    extern fn zguiStyleColorsClassic(style: *Style) void;
 
     pub fn getColor(style: Style, idx: StyleCol) [4]f32 {
         return style.colors[@intCast(@intFromEnum(idx))];
@@ -1088,6 +1094,18 @@ pub const Style = extern struct {
 /// `pub fn getStyle() *Style`
 pub const getStyle = zguiGetStyle;
 extern fn zguiGetStyle() *Style;
+
+/// `pub fn styleColorsDark(*Style)`
+pub const styleColorsDark = zguiStyleColorsDark;
+extern fn zguiStyleColorsDark(style: *Style) void;
+
+/// `pub fn styleColorsLight(*Style)`
+pub const styleColorsLight = zguiStyleColorsLight;
+extern fn zguiStyleColorsLight(style: *Style) void;
+
+/// `pub fn styleColorsClassic(*Style)`
+pub const styleColorsClassic = zguiStyleColorsClassic;
+extern fn zguiStyleColorsClassic(style: *Style) void;
 //--------------------------------------------------------------------------------------------------
 pub const StyleCol = enum(c_int) {
     text,

--- a/libs/zgui/src/zgui.cpp
+++ b/libs/zgui/src/zgui.cpp
@@ -1216,6 +1216,21 @@ extern "C"
         style->ScaleAllSizes(scale_factor);
     }
 
+    ZGUI_API void zguiStyleColorsDark(ImGuiStyle *style)
+    {
+        ImGui::StyleColorsDark(style);
+    }
+
+    ZGUI_API void zguiStyleColorsLight(ImGuiStyle *style)
+    {
+        ImGui::StyleColorsLight(style);
+    }
+
+    ZGUI_API void zguiStyleColorsClassic(ImGuiStyle *style)
+    {
+        ImGui::StyleColorsClassic(style);
+    }
+
     ZGUI_API void zguiPushStyleColor4f(ImGuiCol idx, const float col[4])
     {
         ImGui::PushStyleColor(idx, {col[0], col[1], col[2], col[3]});


### PR DESCRIPTION
This adds the `ImGui::StyleColors{Dark,Light,Classic}` API to the `zgui.Style` struct.

Compressing these functions to a single function with a style variant argument and naming it `Style.setDefaultColors` is a choice that's up for debate. It seems kinda nice to me, but I'm open to changing it to whatever if people disagree.