### PR TITLE
zphysics: Fixed DebugRenderer for double precision builds, created explicit RMatrix class

### DIFF
--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
@@ -810,8 +810,7 @@ public:
         JPH::DebugRenderer::ECastShadow inCastShadow,
         JPH::DebugRenderer::EDrawMode inDrawMode) override
     {
-        float in_model_matrix[16]; // Model matrix will always be rounded to floats (JPH samples assume the same).
-        storeMat44(in_model_matrix, inModelMatrix.ToMat44());
+        auto in_model_matrix = reinterpret_cast<const JPC_RMatrix*>(&inModelMatrix);
         JPC_DebugRenderer_Geometry in_geometry {
             toJpc(&inGeometry.GetPtr()->mLODs[0]),
             static_cast<uint64_t>(inGeometry.GetPtr()->mLODs.size()),

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.h
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.h
@@ -605,6 +605,14 @@ typedef struct JPC_AABox
     alignas(16) float max[3];
 } JPC_AABox;
 
+typedef struct JPC_RMatrix
+{
+    alignas(16) float column_0[4];
+    alignas(16) float column_1[4];
+    alignas(16) float column_2[4];
+    JPC_RVEC_ALIGN JPC_Real column_3[4];
+} JPC_RMatrix;
+
 typedef struct JPC_Shape_SupportingFace
 {
     alignas(16) uint32_t num_points;
@@ -903,7 +911,7 @@ typedef struct JPC_DebugRendererVTable
     // Required, *cannot* be NULL.
     void
     (*DrawGeometry)(void *in_self,
-                    const float inModelMatrix[16],
+                    const JPC_RMatrix* inModelMatrix,
                     const JPC_AABox *inWorldSpaceBounds,
                     float inLODScaleSq,
                     JPC_Color in_color,

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC_Extensions.cpp
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC_Extensions.cpp
@@ -148,6 +148,9 @@ ENSURE_SIZE_ALIGN(JPH::RayCast, JPC_RayCast)
 ENSURE_SIZE_ALIGN(JPH::RRayCast, JPC_RRayCast)
 ENSURE_SIZE_ALIGN(JPH::RayCastResult, JPC_RayCastResult)
 ENSURE_SIZE_ALIGN(JPH::RayCastSettings, JPC_RayCastSettings)
+
+ENSURE_SIZE_ALIGN(JPH::AABox, JPC_AABox)
+ENSURE_SIZE_ALIGN(JPH::RMat44, JPC_RMatrix)
 //--------------------------------------------------------------------------------------------------
 #define ENSURE_ENUM_EQ(c_const, cpp_enum) static_assert(c_const == static_cast<int>(cpp_enum))
 

--- a/libs/zphysics/src/zphysics.zig
+++ b/libs/zphysics/src/zphysics.zig
@@ -971,6 +971,19 @@ pub const AABox = extern struct {
     }
 };
 
+pub const RMatrix = extern struct {
+    column_0: [4]f32 align(16),
+    column_1: [4]f32 align(16),
+    column_2: [4]f32 align(16),
+    column_3: [4]Real align(rvec_align),
+
+    comptime {
+        assert(@sizeOf(RMatrix) == @sizeOf(c.JPC_RMatrix));
+        assert(@offsetOf(RMatrix, "column_1") == @offsetOf(c.JPC_RMatrix, "column_1"));
+        assert(@offsetOf(RMatrix, "column_3") == @offsetOf(c.JPC_RMatrix, "column_3"));
+    }
+};
+
 pub const DebugRenderer = if (!debug_renderer_enabled) extern struct {} else extern struct {
     pub fn createSingleton(debug_renderer_impl: *anyopaque) !void {
         switch (@as(DebugRendererResult, @enumFromInt(c.JPC_CreateDebugRendererSingleton(debug_renderer_impl)))) {
@@ -1067,7 +1080,7 @@ pub const DebugRenderer = if (!debug_renderer_enabled) extern struct {} else ext
             }
             pub inline fn drawGeometry(
                 self: *T,
-                model_matrix: *const [16]Real,
+                model_matrix: *const RMatrix,
                 world_space_bound: *const AABox,
                 lod_scale_sq: f32,
                 color: Color,
@@ -1137,7 +1150,7 @@ pub const DebugRenderer = if (!debug_renderer_enabled) extern struct {} else ext
             ) callconv(.C) *anyopaque = null,
             drawGeometry: ?*const fn (
                 self: *T,
-                model_matrix: *const [16]Real,
+                model_matrix: *const RMatrix,
                 world_space_bound: *const AABox,
                 lod_scale_sq: f32,
                 color: Color,
@@ -4626,7 +4639,7 @@ const test_cb1 = struct {
         }
         fn drawGeometry(
             self: *MyDebugRenderer,
-            model_matrix: *const [16]Real,
+            model_matrix: *const RMatrix,
             world_space_bound: *const AABox,
             lod_scale_sq: f32,
             color: DebugRenderer.Color,


### PR DESCRIPTION
Also updated the monolith demo to reflect the changes.

Before, while fixing the double precision builds, I missed something in DebugRenderer that wasn't correct. I'm basically just adding this fix.

DebugRenderer should now work in both precision modes, instead of just in single precision mode.