### PR TITLE
[breaking] refactor zsdl prebuilt libs

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -60,9 +60,20 @@
         },
 
         .zsdl = .{ .path = "libs/zsdl" },
-        .@"sdl2-prebuilt" = .{
-            .url = "https://github.com/zig-gamedev/SDL2-prebuilt/archive/01ed17a8a2c85943be82fd9638212a1f1ab6f2b9.tar.gz",
-            .hash = "122028412e5d640fdf21044d4d0ac1287e1bc976e87859d2da6a716eb4fe1326f630",
+        .@"sdl2-prebuilt-macos" = .{
+            .url = "https://github.com/zig-gamedev/sdl2-prebuilt-macos/archive/f14773fa3de719b3a399b854c31eb4139d63842f.tar.gz",
+            .hash = "12205cb2da6fb4a7fcf28b9cd27b60aaf12f4d4a55be0260b1ae36eaf93ca5a99f03",
+            .lazy = true,
+        },
+        .@"sdl2-prebuilt-x86_64-linux-gnu" = .{
+            .url = "https://github.com/zig-gamedev/sdl2-prebuilt-x86_64-linux-gnu/archive/1919257cc632bb31369b46030c0e9f95af525487.tar.gz",
+            .hash = "1220703f44b559bd5efe9effbdd90a55b80ed5cfa4c39e01652258433bba18aad672",
+            .lazy = true,
+        },
+        .@"sdl2-prebuilt-x86_64-windows-gnu" = .{
+            .url = "https://github.com/zig-gamedev/sdl2-prebuilt-x86_64-windows-gnu/archive/8143e2a5c28dbace399cbff14c3e8749a1afd418.tar.gz",
+            .hash = "1220ade6b84d06d73bf83cef22c73ec4abc21a6d50b9f48875f348b7942c80dde11b",
+            .lazy = true,
         },
     },
 }

--- a/experiments/genart/build.zig
+++ b/experiments/genart/build.zig
@@ -77,10 +77,7 @@ fn install(
     exe.root_module.addImport("zsdl2", zsdl2_module);
 
     @import("zsdl").link_SDL2(exe);
-
-    const sdl2_libs_path = b.dependency("sdl2-prebuilt", .{}).path("").getPath(b);
-    @import("zsdl").addLibraryPathsTo(sdl2_libs_path, exe);
-    @import("zsdl").addRPathsTo(sdl2_libs_path, exe);
+    @import("zsdl").prebuilt.addLibraryPathsTo(exe);
 
     exe.root_module.addImport("zopengl", zopengl_module);
 
@@ -90,7 +87,7 @@ fn install(
     );
     install_step.dependOn(&b.addInstallArtifact(exe, .{}).step);
 
-    if (@import("zsdl").install_SDL2(b, target.result, sdl2_libs_path, .bin)) |install_sdl2_step| {
+    if (@import("zsdl").prebuilt.install_SDL2(b, target.result, .bin)) |install_sdl2_step| {
         install_step.dependOn(install_sdl2_step);
     }
 

--- a/libs/zsdl/README.md
+++ b/libs/zsdl/README.md
@@ -7,11 +7,22 @@ Copy `zsdl` folder to a subdirectory of your project and add the following to yo
 ```zig
         .zsdl = .{ .path = "path/to/local/zsdl" },
 ```
-also add `SDL2-prebuilt` if you want to use our prebuilt libraries instead of system installed
+also add the following if you want to use our prebuilt libraries instead of system installed dependencies
 ```zig
-        .@"sdl2-prebuilt" = .{
-            .url = "https://github.com/zig-gamedev/SDL2-prebuilt/archive/49b2267a0fedee9d594733617255dd979da51813.tar.gz",
-            .hash = "1220930ce0d568bd606112d38c3f16a38841a5fd9de5c224f627cd953e7febb90bfa",
+        .@"sdl2-prebuilt-macos" = .{
+            .url = "https://github.com/zig-gamedev/sdl2-prebuilt-macos/archive/f14773fa3de719b3a399b854c31eb4139d63842f.tar.gz",
+            .hash = "12205cb2da6fb4a7fcf28b9cd27b60aaf12f4d4a55be0260b1ae36eaf93ca5a99f03",
+            .lazy = true,
+        },
+        .@"sdl2-prebuilt-x86_64-linux-gnu" = .{
+            .url = "https://github.com/zig-gamedev/sdl2-prebuilt-x86_64-linux-gnu/archive/1919257cc632bb31369b46030c0e9f95af525487.tar.gz",
+            .hash = "1220703f44b559bd5efe9effbdd90a55b80ed5cfa4c39e01652258433bba18aad672",
+            .lazy = true,
+        },
+        .@"sdl2-prebuilt-x86_64-windows-gnu" = .{
+            .url = "https://github.com/zig-gamedev/sdl2-prebuilt-x86_64-windows-gnu/archive/8143e2a5c28dbace399cbff14c3e8749a1afd418.tar.gz",
+            .hash = "1220ade6b84d06d73bf83cef22c73ec4abc21a6d50b9f48875f348b7942c80dde11b",
+            .lazy = true,
         },
 ```
 
@@ -25,16 +36,13 @@ pub fn build(b: *std.Build) !void {
     const zsdl = b.dependency("zsdl", .{});
     exe.root_module.addImport("zsdl2", zsdl.module("zsdl2"));
 
-    @import("zsdl").link_SDL2(exe);
+    @import("zsdl").prebuilt.addLibraryPathsTo(exe);
 
-    const sdl2_libs_path = b.dependency("sdl2-prebuilt", .{}).path("").getPath(b);
-
-    @import("zsdl").addLibraryPathsTo(sdl2_libs_path, exe);
-    @import("zsdl").addRPathsTo(sdl2_libs_path, exe);
-
-    if (@import("zsdl").install_SDL2(b, target.result, sdl2_libs_path, .bin)) |install_sdl2_step| {
+    if (@import("zsdl").prebuilt.install_SDL2(b, target.result, .bin)) |install_sdl2_step| {
         b.getInstallStep().dependOn(install_sdl2_step);
     }
+
+    @import("zsdl").link_SDL2(exe);
 }
 ```
 

--- a/libs/zsdl/build.zig
+++ b/libs/zsdl/build.zig
@@ -34,9 +34,11 @@ pub fn link_SDL2(compile_step: *std.Build.Step.Compile) void {
         },
         .linux => {
             compile_step.linkSystemLibrary("SDL2");
+            compile_step.root_module.addRPathSpecial("$ORIGIN");
         },
         .macos => {
             compile_step.linkFramework("SDL2");
+            compile_step.root_module.addRPathSpecial("@executable_path");
         },
         else => {},
     }
@@ -49,9 +51,11 @@ pub fn link_SDL2_ttf(compile_step: *std.Build.Step.Compile) void {
         },
         .linux => {
             compile_step.linkSystemLibrary("SDL2_ttf");
+            compile_step.root_module.addRPathSpecial("$ORIGIN");
         },
         .macos => {
             compile_step.linkFramework("SDL2_ttf");
+            compile_step.root_module.addRPathSpecial("@executable_path");
         },
         else => {},
     }
@@ -64,9 +68,11 @@ pub fn link_SDL2_image(compile_step: *std.Build.Step.Compile) void {
         },
         .linux => {
             compile_step.linkSystemLibrary("SDL2_image");
+            compile_step.root_module.addRPathSpecial("$ORIGIN");
         },
         .macos => {
             compile_step.linkFramework("SDL2_image");
+            compile_step.root_module.addRPathSpecial("@executable_path");
         },
         else => {},
     }
@@ -89,177 +95,7 @@ pub fn link_SDL3(compile_step: *std.Build.Step.Compile) void {
     }
 }
 
-pub fn addLibraryPathsTo(libs_source_path: []const u8, compile_step: *std.Build.Step.Compile) void {
-    const b = compile_step.step.owner;
-    const target = compile_step.rootModuleTarget();
-    switch (target.os.tag) {
-        .windows => {
-            if (target.cpu.arch.isX86()) {
-                compile_step.addLibraryPath(.{
-                    .cwd_relative = b.pathJoin(&.{ libs_source_path, "x86_64-windows-gnu/lib" }),
-                });
-            }
-        },
-        .linux => {
-            if (target.cpu.arch.isX86()) {
-                compile_step.addLibraryPath(.{
-                    .cwd_relative = b.pathJoin(&.{ libs_source_path, "x86_64-linux-gnu/lib" }),
-                });
-            }
-        },
-        .macos => {
-            compile_step.addFrameworkPath(.{
-                .cwd_relative = b.pathJoin(&.{ libs_source_path, "macos/Frameworks" }),
-            });
-        },
-        else => {},
-    }
-}
-
-pub fn addRPathsTo(libs_source_path: []const u8, compile_step: *std.Build.Step.Compile) void {
-    const b = compile_step.step.owner;
-    const target = compile_step.rootModuleTarget();
-    switch (target.os.tag) {
-        .windows => {
-            if (target.cpu.arch.isX86()) {
-                compile_step.addRPath(.{
-                    .cwd_relative = b.pathJoin(&.{ libs_source_path, "x86_64-windows-gnu/bin" }),
-                });
-            }
-            compile_step.root_module.addRPathSpecial("$ORIGIN");
-        },
-        .linux => {
-            if (target.cpu.arch.isX86()) {
-                compile_step.addRPath(.{
-                    .cwd_relative = b.pathJoin(&.{ libs_source_path, "x86_64-linux-gnu/lib" }),
-                });
-            }
-            compile_step.root_module.addRPathSpecial("@executable_path");
-        },
-        .macos => {
-            compile_step.addRPath(.{
-                .cwd_relative = b.pathJoin(&.{ libs_source_path, "macos/Frameworks" }),
-            });
-        },
-        else => {},
-    }
-}
-
-pub fn install_SDL2(
-    b: *std.Build,
-    target: std.Target,
-    libs_source_path: []const u8,
-    install_dir: std.Build.InstallDir,
-) ?*std.Build.Step {
-    switch (target.os.tag) {
-        .windows => {
-            if (target.cpu.arch.isX86()) {
-                return &b.addInstallFileWithDir(
-                    .{ .cwd_relative = b.pathJoin(&.{ libs_source_path, "x86_64-windows-gnu/bin/SDL2.dll" }) },
-                    install_dir,
-                    "SDL2.dll",
-                ).step;
-            }
-        },
-        .linux => {
-            if (target.cpu.arch.isX86()) {
-                return &b.addInstallFileWithDir(
-                    .{ .cwd_relative = b.pathJoin(&.{ libs_source_path, "x86_64-linux-gnu/lib/libSDL2.so" }) },
-                    install_dir,
-                    "libSDL2.so",
-                ).step;
-            }
-        },
-        .macos => {
-            return &b.addInstallDirectory(.{
-                .source_dir = .{ .cwd_relative = b.pathJoin(&.{ libs_source_path, "macos/Frameworks/SDL2.framework" }) },
-                .install_dir = install_dir,
-                .install_subdir = "SDL2.framework",
-            }).step;
-        },
-        else => {},
-    }
-    return null;
-}
-
-pub fn install_SDL2_ttf(
-    b: *std.Build,
-    target: std.Target,
-    libs_source_path: []const u8,
-    install_dir: std.Build.InstallDir,
-) ?*std.Build.Step {
-    switch (target.os.tag) {
-        .windows => {
-            if (target.cpu.arch.isX86()) {
-                return &b.addInstallFileWithDir(
-                    .{ .cwd_relative = b.pathJoin(&.{ libs_source_path, "x86_64-windows-gnu/bin/SDL2_ttf.dll" }) },
-                    install_dir,
-                    "SDL2_ttf.dll",
-                ).step;
-            }
-        },
-        .linux => {
-            if (target.cpu.arch.isX86()) {
-                return &b.addInstallFileWithDir(
-                    .{ .cwd_relative = b.pathJoin(&.{ libs_source_path, "x86_64-linux-gnu/lib/libSDL2_ttf.so" }) },
-                    install_dir,
-                    "libSDL2_ttf.so",
-                ).step;
-            }
-        },
-        .macos => {
-            return &b.addInstallDirectory(.{
-                .source_dir = .{ .cwd_relative = b.pathJoin(&.{ libs_source_path, "macos/Frameworks/SDL2_ttf.framework" }) },
-                .install_dir = install_dir,
-                .install_subdir = "SDL2_ttf.framework",
-            }).step;
-        },
-        else => {},
-    }
-    return null;
-}
-
-pub fn install_SDL2_image(
-    b: *std.Build,
-    target: std.Target,
-    libs_source_path: []const u8,
-    install_dir: std.Build.InstallDir,
-) ?*std.Build.Step {
-    switch (target.os.tag) {
-        .windows => {
-            if (target.cpu.arch.isX86()) {
-                return &b.addInstallFileWithDir(
-                    .{ .cwd_relative = b.pathJoin(&.{ libs_source_path, "x86_64-windows-gnu/bin/SDL2_image.dll" }) },
-                    install_dir,
-                    "SDL2_image.dll",
-                ).step;
-            }
-        },
-        .linux => {
-            if (target.cpu.arch.isX86()) {
-                return &b.addInstallFileWithDir(
-                    .{ .cwd_relative = b.pathJoin(&.{ libs_source_path, "x86_64-linux-gnu/lib/libSDL2_image.so" }) },
-                    install_dir,
-                    "libSDL2_image.so",
-                ).step;
-            }
-        },
-        .macos => {
-            return &b.addInstallDirectory(.{
-                .source_dir = .{ .cwd_relative = b.pathJoin(&.{ libs_source_path, "macos/Frameworks/SDL2_image.framework" }) },
-                .install_dir = install_dir,
-                .install_subdir = "SDL2_image.framework",
-            }).step;
-        },
-        else => {},
-    }
-    return null;
-}
-
 pub fn testVersionCheckSDL2(b: *std.Build, target: std.Build.ResolvedTarget) *std.Build.Step {
-    const sdl2_prebuilt = b.lazyDependency("sdl2-prebuilt", .{}).?;
-    const sdl2_libs_path = sdl2_prebuilt.path("").getPath(b);
-
     const test_sdl2_version_check = b.addTest(.{
         .name = "sdl2-version-check",
         .root_source_file = b.dependency("zsdl", .{}).path("src/sdl2_version_check.zig"),
@@ -269,8 +105,7 @@ pub fn testVersionCheckSDL2(b: *std.Build, target: std.Build.ResolvedTarget) *st
 
     link_SDL2(test_sdl2_version_check);
 
-    addLibraryPathsTo(sdl2_libs_path, test_sdl2_version_check);
-    addRPathsTo(sdl2_libs_path, test_sdl2_version_check);
+    prebuilt.addLibraryPathsTo(test_sdl2_version_check);
 
     const version_check_run = b.addRunArtifact(test_sdl2_version_check);
 
@@ -282,9 +117,200 @@ pub fn testVersionCheckSDL2(b: *std.Build, target: std.Build.ResolvedTarget) *st
 
     version_check_run.step.dependOn(&test_sdl2_version_check.step);
 
-    if (install_SDL2(b, target.result, sdl2_libs_path, .bin)) |install_sdl2_step| {
+    if (prebuilt.install_SDL2(b, target.result, .bin)) |install_sdl2_step| {
         version_check_run.step.dependOn(install_sdl2_step);
     }
 
     return &version_check_run.step;
 }
+
+pub const prebuilt = struct {
+    pub fn addLibraryPathsTo(compile_step: *std.Build.Step.Compile) void {
+        const b = compile_step.step.owner;
+        const target = compile_step.rootModuleTarget();
+        switch (target.os.tag) {
+            .windows => {
+                if (target.cpu.arch.isX86()) {
+                    if (b.lazyDependency("sdl2-prebuilt-x86_64-windows-gnu", .{})) |sdl2_prebuilt| {
+                        compile_step.addLibraryPath(.{ .dependency = .{
+                            .dependency = sdl2_prebuilt,
+                            .sub_path = "lib",
+                        } });
+                    }
+                }
+            },
+            .linux => {
+                if (target.cpu.arch.isX86()) {
+                    if (b.lazyDependency("sdl2-prebuilt-x86_64-linux-gnu", .{})) |sdl2_prebuilt| {
+                        compile_step.addLibraryPath(.{ .dependency = .{
+                            .dependency = sdl2_prebuilt,
+                            .sub_path = "lib",
+                        } });
+                    }
+                }
+            },
+            .macos => {
+                if (b.lazyDependency("sdl2-prebuilt-macos", .{})) |sdl2_prebuilt| {
+                    compile_step.addFrameworkPath(.{ .dependency = .{
+                        .dependency = sdl2_prebuilt,
+                        .sub_path = "Frameworks",
+                    } });
+                }
+            },
+            else => {},
+        }
+    }
+
+    pub fn install_SDL2(
+        b: *std.Build,
+        target: std.Target,
+        install_dir: std.Build.InstallDir,
+    ) ?*std.Build.Step {
+        switch (target.os.tag) {
+            .windows => {
+                if (target.cpu.arch.isX86()) {
+                    if (b.lazyDependency("sdl2-prebuilt-x86_64-windows-gnu", .{})) |sdl2_prebuilt| {
+                        return &b.addInstallFileWithDir(
+                            .{ .dependency = .{
+                                .dependency = sdl2_prebuilt,
+                                .sub_path = "bin/SDL2.dll",
+                            } },
+                            install_dir,
+                            "SDL2.dll",
+                        ).step;
+                    }
+                }
+            },
+            .linux => {
+                if (target.cpu.arch.isX86()) {
+                    if (b.lazyDependency("sdl2-prebuilt-x86_64-linux-gnu", .{})) |sdl2_prebuilt| {
+                        return &b.addInstallFileWithDir(
+                            .{ .dependency = .{
+                                .dependency = sdl2_prebuilt,
+                                .sub_path = "lib/libSDL2.so",
+                            } },
+                            install_dir,
+                            "libSDL2.so",
+                        ).step;
+                    }
+                }
+            },
+            .macos => {
+                if (b.lazyDependency("sdl2-prebuilt-macos", .{})) |sdl2_prebuilt| {
+                    return &b.addInstallDirectory(.{
+                        .source_dir = .{ .dependency = .{
+                            .dependency = sdl2_prebuilt,
+                            .sub_path = "Frameworks/SDL2.framework",
+                        } },
+                        .install_dir = install_dir,
+                        .install_subdir = "SDL2.framework",
+                    }).step;
+                }
+            },
+            else => {},
+        }
+        return null;
+    }
+
+    pub fn install_SDL2_ttf(
+        b: *std.Build,
+        target: std.Target,
+        install_dir: std.Build.InstallDir,
+    ) ?*std.Build.Step {
+        switch (target.os.tag) {
+            .windows => {
+                if (target.cpu.arch.isX86()) {
+                    if (b.lazyDependency("sdl2-prebuilt-x86_64-windows-gnu", .{})) |sdl2_prebuilt| {
+                        return &b.addInstallFileWithDir(
+                            .{ .dependency = .{
+                                .dependency = sdl2_prebuilt,
+                                .sub_path = "bin/SDL2_ttf.dll",
+                            } },
+                            install_dir,
+                            "SDL2_ttf.dll",
+                        ).step;
+                    }
+                }
+            },
+            .linux => {
+                if (target.cpu.arch.isX86()) {
+                    if (b.lazyDependency("sdl2-prebuilt-x86_64-linux-gnu", .{})) |sdl2_prebuilt| {
+                        return &b.addInstallFileWithDir(
+                            .{ .dependency = .{
+                                .dependency = sdl2_prebuilt,
+                                .sub_path = "lib/libSDL2_ttf.so",
+                            } },
+                            install_dir,
+                            "libSDL2_ttf.so",
+                        ).step;
+                    }
+                }
+            },
+            .macos => {
+                if (b.lazyDependency("sdl2-prebuilt-macos", .{})) |sdl2_prebuilt| {
+                    return &b.addInstallDirectory(.{
+                        .source_dir = .{ .dependency = .{
+                            .dependency = sdl2_prebuilt,
+                            .sub_path = "Frameworks/SDL2_ttf.framework",
+                        } },
+                        .install_dir = install_dir,
+                        .install_subdir = "SDL2_ttf.framework",
+                    }).step;
+                }
+            },
+            else => {},
+        }
+        return null;
+    }
+
+    pub fn install_SDL2_image(
+        b: *std.Build,
+        target: std.Target,
+        install_dir: std.Build.InstallDir,
+    ) ?*std.Build.Step {
+        switch (target.os.tag) {
+            .windows => {
+                if (target.cpu.arch.isX86()) {
+                    if (b.lazyDependency("sdl2-prebuilt-x86_64-windows-gnu", .{})) |sdl2_prebuilt| {
+                        return &b.addInstallFileWithDir(
+                            .{ .dependency = .{
+                                .dependency = sdl2_prebuilt,
+                                .sub_path = "bin/SDL2_image.dll",
+                            } },
+                            install_dir,
+                            "SDL2_image.dll",
+                        ).step;
+                    }
+                }
+            },
+            .linux => {
+                if (target.cpu.arch.isX86()) {
+                    if (b.lazyDependency("sdl2-prebuilt-x86_64-linux-gnu", .{})) |sdl2_prebuilt| {
+                        return &b.addInstallFileWithDir(
+                            .{ .dependency = .{
+                                .dependency = sdl2_prebuilt,
+                                .sub_path = "lib/libSDL2_image.so",
+                            } },
+                            install_dir,
+                            "libSDL2_image.so",
+                        ).step;
+                    }
+                }
+            },
+            .macos => {
+                if (b.lazyDependency("sdl2-prebuilt-macos", .{})) |sdl2_prebuilt| {
+                    return &b.addInstallDirectory(.{
+                        .source_dir = .{ .dependency = .{
+                            .dependency = sdl2_prebuilt,
+                            .sub_path = "Frameworks/SDL2_image.framework",
+                        } },
+                        .install_dir = install_dir,
+                        .install_subdir = "SDL2_image.framework",
+                    }).step;
+                }
+            },
+            else => {},
+        }
+        return null;
+    }
+};

--- a/libs/zsdl/build.zig.zon
+++ b/libs/zsdl/build.zig.zon
@@ -1,13 +1,23 @@
 .{
     .name = "zsdl",
-    .version = "0.2.0",
+    .version = "0.3.0",
 
     .min_zig_version = "0.13.0",
 
     .dependencies = .{
-        .@"sdl2-prebuilt" = .{
-            .url = "https://github.com/zig-gamedev/SDL2-prebuilt/archive/01ed17a8a2c85943be82fd9638212a1f1ab6f2b9.tar.gz",
-            .hash = "122028412e5d640fdf21044d4d0ac1287e1bc976e87859d2da6a716eb4fe1326f630",
+        .@"sdl2-prebuilt-macos" = .{
+            .url = "https://github.com/zig-gamedev/sdl2-prebuilt-macos/archive/f14773fa3de719b3a399b854c31eb4139d63842f.tar.gz",
+            .hash = "12205cb2da6fb4a7fcf28b9cd27b60aaf12f4d4a55be0260b1ae36eaf93ca5a99f03",
+            .lazy = true,
+        },
+        .@"sdl2-prebuilt-x86_64-linux-gnu" = .{
+            .url = "https://github.com/zig-gamedev/sdl2-prebuilt-x86_64-linux-gnu/archive/1919257cc632bb31369b46030c0e9f95af525487.tar.gz",
+            .hash = "1220703f44b559bd5efe9effbdd90a55b80ed5cfa4c39e01652258433bba18aad672",
+            .lazy = true,
+        },
+        .@"sdl2-prebuilt-x86_64-windows-gnu" = .{
+            .url = "https://github.com/zig-gamedev/sdl2-prebuilt-x86_64-windows-gnu/archive/8143e2a5c28dbace399cbff14c3e8749a1afd418.tar.gz",
+            .hash = "1220ade6b84d06d73bf83cef22c73ec4abc21a6d50b9f48875f348b7942c80dde11b",
             .lazy = true,
         },
     },
@@ -15,7 +25,6 @@
     .paths = .{
         "build.zig",
         "build.zig.zon",
-        "libs",
         "src",
         "README.md",
     },

--- a/samples/minimal_sdl_gl/build.zig
+++ b/samples/minimal_sdl_gl/build.zig
@@ -15,16 +15,13 @@ pub fn build(b: *std.Build, options: anytype) *std.Build.Step.Compile {
     const zsdl = b.dependency("zsdl", .{});
     exe.root_module.addImport("zsdl2", zsdl.module("zsdl2"));
 
-    @import("zsdl").link_SDL2(exe);
+    @import("zsdl").prebuilt.addLibraryPathsTo(exe);
 
-    const sdl2_libs_path = b.dependency("sdl2-prebuilt", .{}).path("").getPath(b);
-
-    @import("zsdl").addLibraryPathsTo(sdl2_libs_path, exe);
-    @import("zsdl").addRPathsTo(sdl2_libs_path, exe);
-
-    if (@import("zsdl").install_SDL2(b, options.target.result, sdl2_libs_path, .bin)) |install_sdl2_step| {
+    if (@import("zsdl").prebuilt.install_SDL2(b, options.target.result, .bin)) |install_sdl2_step| {
         exe.step.dependOn(install_sdl2_step);
     }
+
+    @import("zsdl").link_SDL2(exe);
 
     const zopengl = b.dependency("zopengl", .{});
     exe.root_module.addImport("zopengl", zopengl.module("root"));


### PR DESCRIPTION
Split `sdl2-prebuilt` into `sdl2-prebuilt-macos`, `sdl2-prebuilt-x86_64-linux-gnu` and `sdl2-prebuilt-x86_64-windows-gnu` and consume them lazily.