### PR TITLE
zphysics: Expose CharacterVirtual.ExtendedUpdate

### DIFF
--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
@@ -3130,6 +3130,34 @@ JPC_CharacterVirtual_Update(JPC_CharacterVirtual *in_character,
         *reinterpret_cast<JPH::TempAllocator *>(in_temp_allocator));
 }
 //--------------------------------------------------------------------------------------------------
+JPC_API void
+JPC_CharacterVirtual_ExtendedUpdate(JPC_CharacterVirtual *in_character,
+                                    float in_delta_time,
+                                    const float in_gravity[3],
+                                    const void *in_settings,
+                                    const void *in_broad_phase_layer_filter,
+                                    const void *in_object_layer_filter,
+                                    const void *in_body_filter,
+                                    const void *in_shape_filter,
+                                    JPC_TempAllocator *in_temp_allocator)
+{
+    const JPH::BroadPhaseLayerFilter broad_phase_layer_filter{};
+    const JPH::ObjectLayerFilter object_layer_filter{};
+    const JPH::BodyFilter body_filter{};
+    const JPH::ShapeFilter shape_filter{};
+    toJph(in_character)->ExtendedUpdate(
+        in_delta_time,
+        loadVec3(in_gravity),
+        *static_cast<const JPH::CharacterVirtual::ExtendedUpdateSettings *>(in_settings),
+        in_broad_phase_layer_filter ?
+        *static_cast<const JPH::BroadPhaseLayerFilter *>(in_broad_phase_layer_filter) : broad_phase_layer_filter,
+        in_object_layer_filter ?
+        *static_cast<const JPH::ObjectLayerFilter *>(in_object_layer_filter) : object_layer_filter,
+        in_body_filter ? *static_cast<const JPH::BodyFilter *>(in_body_filter) : body_filter,
+        in_shape_filter ? *static_cast<const JPH::ShapeFilter *>(in_shape_filter) : shape_filter,
+        *reinterpret_cast<JPH::TempAllocator *>(in_temp_allocator));
+}
+//--------------------------------------------------------------------------------------------------
 JPC_API JPC_CharacterGroundState
 JPC_CharacterVirtual_GetGroundState(JPC_CharacterVirtual *in_character)
 {

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.h
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.h
@@ -660,6 +660,17 @@ typedef struct JPC_Shape_SupportingFace
     alignas(16) float    points[32][4]; // 4th element is ignored; world space
 } JPC_Shape_SupportingFace;
 
+// NOTE: Needs to be kept in sync with JPH::CharacterVirtual::ExtendedUpdateSettings
+typedef struct JPC_CharacterVirtual_ExtendedUpdateSettings
+{
+    alignas(16) float stick_to_floor_step_down[4]; // 4th element is ignored;
+    alignas(16) float walk_stairs_step_up[4]; // 4th element is ignored;
+    float             walk_stairs_min_step_forward;
+    float             walk_stairs_step_forward_test;
+    float             walk_stairs_cos_angle_forward_contact;
+    alignas(16) float walk_stairs_step_down_extra[4]; // 4th element is ignored;
+} JPC_CharacterVirtual_ExtendedUpdateSettings;
+
 #if JPC_DEBUG_RENDERER == 1
 // NOTE: Needs to be kept in sync with JPH::AABox
 
@@ -2223,6 +2234,17 @@ JPC_API void
 JPC_CharacterVirtual_Update(JPC_CharacterVirtual *in_character,
                             float in_delta_time,
                             const float in_gravity[3],
+                            const void *in_broad_phase_layer_filter,
+                            const void *in_object_layer_filter,
+                            const void *in_body_filter,
+                            const void *in_shape_filter,
+                            JPC_TempAllocator *in_temp_allocator);
+
+JPC_API void
+JPC_CharacterVirtual_ExtendedUpdate(JPC_CharacterVirtual *in_character,
+                            float in_delta_time,
+                            const float in_gravity[3],
+                            const void *in_settings,
                             const void *in_broad_phase_layer_filter,
                             const void *in_object_layer_filter,
                             const void *in_body_filter,

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC_Extensions.cpp
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC_Extensions.cpp
@@ -161,7 +161,8 @@ ENSURE_SIZE_ALIGN(JPH::CharacterVirtualSettings, JPC_CharacterVirtualSettings)
 ENSURE_SIZE_ALIGN(JPH::AABox, JPC_AABox)
 ENSURE_SIZE_ALIGN(JPH::RMat44, JPC_RMatrix)
 
-ENSURE_SIZE_ALIGN(JPH::RMat44, JPC_RMatrix)
+ENSURE_SIZE_ALIGN(JPH::Shape::SupportingFace, JPC_Shape_SupportingFace)
+ENSURE_SIZE_ALIGN(JPH::CharacterVirtual::ExtendedUpdateSettings, JPC_CharacterVirtual_ExtendedUpdateSettings)
 
 //--------------------------------------------------------------------------------------------------
 #define ENSURE_ENUM_EQ(c_const, cpp_enum) static_assert(c_const == static_cast<int>(cpp_enum))

--- a/libs/zphysics/src/zphysics.zig
+++ b/libs/zphysics/src/zphysics.zig
@@ -2488,6 +2488,21 @@ pub const Character = opaque {
 //
 //--------------------------------------------------------------------------------------------------
 pub const CharacterVirtual = opaque {
+    pub const ExtendedUpdateSettings = extern struct {
+        stick_to_floor_step_down: [4]f32 align(16) = .{ 0, -0.5, 0, 0 }, // 4th element is ignored
+        walk_stairs_step_up: [4]f32 align(16) = .{ 0, 0.4, 0, 0 }, // 4th element is ignored
+        walk_stairs_min_step_forward: f32 = 0.02,
+        walk_stairs_step_forward_test: f32 = 0.15,
+        walk_stairs_cos_angle_forward_contact: f32 = std.math.cos(std.math.degreesToRadians(75.0)),
+        walk_stairs_step_down_extra: [4]f32 align(16) = .{ 0, 0, 0, 0 }, // 4th element is ignored
+
+        comptime {
+            assert(@sizeOf(ExtendedUpdateSettings) == @sizeOf(c.JPC_CharacterVirtual_ExtendedUpdateSettings));
+            assert(@offsetOf(ExtendedUpdateSettings, "walk_stairs_cos_angle_forward_contact") ==
+                @offsetOf(c.JPC_CharacterVirtual_ExtendedUpdateSettings, "walk_stairs_cos_angle_forward_contact"));
+        }
+    };
+
     pub fn create(
         in_settings: *const CharacterVirtualSettings,
         in_position: [3]Real,
@@ -2521,6 +2536,31 @@ pub const CharacterVirtual = opaque {
             @as(*c.JPC_CharacterVirtual, @ptrCast(character)),
             delta_time,
             &gravity,
+            args.broad_phase_layer_filter,
+            args.object_layer_filter,
+            args.body_filter,
+            args.shape_filter,
+            @as(*c.JPC_TempAllocator, @ptrCast(state.?.temp_allocator)),
+        );
+    }
+
+    pub fn extendedUpdate(
+        character: *CharacterVirtual,
+        delta_time: f32,
+        gravity: [3]f32,
+        settings: *const ExtendedUpdateSettings,
+        args: struct {
+            broad_phase_layer_filter: ?*const BroadPhaseLayerFilter = null,
+            object_layer_filter: ?*const ObjectLayerFilter = null,
+            body_filter: ?*const BodyFilter = null,
+            shape_filter: ?*const ShapeFilter = null,
+        },
+    ) void {
+        c.JPC_CharacterVirtual_ExtendedUpdate(
+            @as(*c.JPC_CharacterVirtual, @ptrCast(character)),
+            delta_time,
+            &gravity,
+            settings,
             args.broad_phase_layer_filter,
             args.object_layer_filter,
             args.body_filter,


### PR DESCRIPTION
Just one more method and an associated struct.

This is the method used in the Jolt samples, and I've been trying to reproduce the behavior of those samples, so ExtendedUpdate was needed.

In the following days, I'll likely have to expose more too, so I'm not sure whether you'd prefer I lump them all together into a single PR, or do a PR for each thing as I complete it like in this case.

As always, please tell me if I've done anything suboptimally.

The one deleted line was because I noticed a duplicate check, and deleted it. It's unrelated to the additions.