### PR TITLE
zmesh, zphysics, and ztracy changes for building for x86_64-windows-msvc

### DIFF
--- a/libs/zglfw/src/zglfw.zig
+++ b/libs/zglfw/src/zglfw.zig
@@ -762,6 +762,14 @@ pub const Window = opaque {
         focused: i32,
     ) callconv(.C) void;
 
+    /// `pub const setIconifyCallback(window: *Window, callback: ?IconifyFn) ?IconifyFn`
+    pub const setIconifyCallback = glfwSetWindowIconifyCallback;
+    extern fn glfwSetWindowIconifyCallback(window: *Window, callback: ?IconifyFn) ?IconifyFn;
+    pub const IconifyFn = *const fn (
+        window: *Window,
+        iconified: i32,
+    ) callconv(.C) void;
+
     /// `pub const setContentScaleCallback(window: *Window, callback: ?WindowContentScaleFn) ?WindowContentScaleFn`
     pub const setContentScaleCallback = glfwSetWindowContentScaleCallback;
     extern fn glfwSetWindowContentScaleCallback(window: *Window, callback: ?WindowContentScaleFn) ?WindowContentScaleFn;

--- a/libs/zmesh/src/memory.zig
+++ b/libs/zmesh/src/memory.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const options = @import("zmesh_options");
 
 pub fn init(alloc: std.mem.Allocator) void {
     std.debug.assert(mem_allocator == null and mem_allocations == null);
@@ -7,10 +8,27 @@ pub fn init(alloc: std.mem.Allocator) void {
     mem_allocations = std.AutoHashMap(usize, usize).init(alloc);
     mem_allocations.?.ensureTotalCapacity(32) catch unreachable;
 
-    zmeshMallocPtr = zmeshMalloc;
-    zmeshCallocPtr = zmeshCalloc;
-    zmeshReallocPtr = zmeshRealloc;
-    zmeshFreePtr = zmeshFree;
+    const zmeshMallocPtr = @extern(*?*const fn (size: usize) callconv(.C) ?*anyopaque, .{
+        .name = "zmeshMallocPtr",
+        .is_dll_import = options.shared,
+    });
+    const zmeshCallocPtr = @extern(*?*const fn (num: usize, size: usize) callconv(.C) ?*anyopaque, .{
+        .name = "zmeshCallocPtr",
+        .is_dll_import = options.shared,
+    });
+    const zmeshReallocPtr = @extern(*?*const fn (ptr: ?*anyopaque, size: usize) callconv(.C) ?*anyopaque, .{
+        .name = "zmeshReallocPtr",
+        .is_dll_import = options.shared,
+    });
+    const zmeshFreePtr = @extern(*?*const fn (maybe_ptr: ?*anyopaque) callconv(.C) void, .{
+        .name = "zmeshFreePtr",
+        .is_dll_import = options.shared,
+    });
+
+    zmeshMallocPtr.* = zmeshMalloc;
+    zmeshCallocPtr.* = zmeshCalloc;
+    zmeshReallocPtr.* = zmeshRealloc;
+    zmeshFreePtr.* = zmeshFree;
     meshopt_setAllocator(zmeshMalloc, zmeshFree);
 }
 
@@ -33,8 +51,6 @@ var mem_allocations: ?std.AutoHashMap(usize, usize) = null;
 var mem_mutex: std.Thread.Mutex = .{};
 const mem_alignment = 16;
 
-extern var zmeshMallocPtr: ?*const fn (size: usize) callconv(.C) ?*anyopaque;
-
 pub fn zmeshMalloc(size: usize) callconv(.C) ?*anyopaque {
     mem_mutex.lock();
     defer mem_mutex.unlock();
@@ -50,8 +66,6 @@ pub fn zmeshMalloc(size: usize) callconv(.C) ?*anyopaque {
     return mem.ptr;
 }
 
-extern var zmeshCallocPtr: ?*const fn (num: usize, size: usize) callconv(.C) ?*anyopaque;
-
 fn zmeshCalloc(num: usize, size: usize) callconv(.C) ?*anyopaque {
     const ptr = zmeshMalloc(num * size);
     if (ptr != null) {
@@ -65,8 +79,6 @@ pub fn zmeshAllocUser(user: ?*anyopaque, size: usize) callconv(.C) ?*anyopaque {
     _ = user;
     return zmeshMalloc(size);
 }
-
-extern var zmeshReallocPtr: ?*const fn (ptr: ?*anyopaque, size: usize) callconv(.C) ?*anyopaque;
 
 fn zmeshRealloc(ptr: ?*anyopaque, size: usize) callconv(.C) ?*anyopaque {
     mem_mutex.lock();
@@ -90,8 +102,6 @@ fn zmeshRealloc(ptr: ?*anyopaque, size: usize) callconv(.C) ?*anyopaque {
 
     return mem.ptr;
 }
-
-extern var zmeshFreePtr: ?*const fn (maybe_ptr: ?*anyopaque) callconv(.C) void;
 
 fn zmeshFree(maybe_ptr: ?*anyopaque) callconv(.C) void {
     if (maybe_ptr) |ptr| {

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.h
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.h
@@ -42,6 +42,18 @@ typedef float JPC_Real;
     #define JPC_DEBUG_RENDERER 0
 #endif
 
+#define _JPC_REFTARGET_HEADER struct { const void * __vfptr_header[1]; uint32_t ref_count; };
+
+#if defined(_MSC_VER)
+#define _JPC_VTABLE_HEADER const void* __vtable_header[1]
+// MSVC quirk: If the first member of a derived class has alignment > 8, then extra padding is inserted such that
+//             the first member of the base class has the same alignment.
+#define _JPC_REFTARGET_HEADER_ALIGN_16 struct { const void * __vtable_ptr[2]; uint32_t ref_count; };
+#else
+#define _JPC_VTABLE_HEADER const void* __vtable_header[2]
+#define _JPC_REFTARGET_HEADER_ALIGN_16 _JPC_REFTARGET_HEADER
+#endif
+
 #define JPC_PI 3.14159265358979323846f
 
 #define JPC_COLLISION_GROUP_INVALID_GROUP 0xffffffff
@@ -469,11 +481,8 @@ typedef struct JPC_Body
 // NOTE: Needs to be kept in sync
 typedef struct JPC_CharacterBaseSettings
 {
-#   if defined(_MSC_VER)
-        const void* __vtable_header[1];
-#   else
-        const void* __vtable_header[2];
-#   endif
+    _JPC_REFTARGET_HEADER_ALIGN_16;
+
     alignas(16) float   up[4]; // 4th element is ignored
     alignas(16) float   supporting_volume[4];
     float               max_slope_angle;
@@ -731,12 +740,6 @@ typedef bool (*JPC_BodyDrawFilterFunc)(const JPC_Body *);
 // Interfaces (virtual tables)
 //
 //--------------------------------------------------------------------------------------------------
-#if defined(_MSC_VER)
-#define _JPC_VTABLE_HEADER const void* __vtable_header[1]
-#else
-#define _JPC_VTABLE_HEADER const void* __vtable_header[2]
-#endif
-
 typedef struct JPC_BroadPhaseLayerInterfaceVTable
 {
     _JPC_VTABLE_HEADER;

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC_Extensions.cpp
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC_Extensions.cpp
@@ -304,6 +304,7 @@ static_assert(offsetof(JPH::RayCastSettings, mBackFaceMode) == offsetof(JPC_RayC
 static_assert(offsetof(JPH::RayCastSettings, mTreatConvexAsSolid) ==
     offsetof(JPC_RayCastSettings, treat_convex_as_solid));
 
+static_assert(offsetof(JPH::CharacterBaseSettings, mRefCount) == offsetof(JPC_CharacterBaseSettings, ref_count));
 static_assert(offsetof(JPH::CharacterBaseSettings, mShape) == offsetof(JPC_CharacterBaseSettings, shape));
 static_assert(offsetof(JPH::CharacterSettings, mGravityFactor) == offsetof(JPC_CharacterSettings, gravity_factor));
 static_assert(offsetof(JPH::CharacterVirtualSettings, mMaxNumHits) ==

--- a/libs/zphysics/src/zphysics.zig
+++ b/libs/zphysics/src/zphysics.zig
@@ -78,6 +78,19 @@ pub const VTableHeader = switch (@import("builtin").abi) {
     },
 };
 
+pub fn RefTargetHeader(comptime first_field_align: u29) type {
+    return switch (@import("builtin").abi) {
+        .msvc => extern struct {
+            __vtable_ptr: ?*const anyopaque = null,
+            __ref_count: u32 align(first_field_align) = 0,
+        },
+        else => extern struct {
+            __vtable_ptr: ?*const anyopaque = null,
+            __ref_count: u32 = 0,
+        },
+    };
+}
+
 pub const BroadPhaseLayerInterface = extern struct {
     __v: *const VTable,
 
@@ -931,7 +944,7 @@ pub const CharacterContactSettings = extern struct {
 };
 
 pub const CharacterBaseSettings = extern struct {
-    __header: VTableHeader = .{},
+    __header: RefTargetHeader(16),
     up: [4]f32 align(16), // 4th element is ignored
     supporting_volume: [4]f32 align(16), // JPH::Plane - 4th element is used
     max_slope_angle: f32,

--- a/libs/ztracy/build.zig
+++ b/libs/ztracy/build.zig
@@ -20,7 +20,11 @@ pub fn build(b: *std.Build) void {
             "on_demand",
             "Build tracy with TRACY_ON_DEMAND",
         ) orelse false,
-        .shared = b.option(bool, "shared", "Build tracy as shared library") orelse false,
+        .shared = b.option(
+            bool,
+            "shared",
+            "Build as shared library",
+        ) orelse false,
     };
 
     const options_step = b.addOptions();
@@ -30,19 +34,33 @@ pub fn build(b: *std.Build) void {
 
     const options_module = options_step.createModule();
 
+    const translate_c = b.addTranslateC(.{
+        .root_source_file = b.path("libs/tracy/tracy/TracyC.h"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    translate_c.addIncludePath(b.path("libs/tracy/tracy"));
+    translate_c.defineCMacro("TRACY_ENABLE", "");
+    translate_c.defineCMacro("TRACY_IMPORTS", "");
+
     const ztracy = b.addModule("root", .{
         .root_source_file = b.path("src/ztracy.zig"),
         .imports = &.{
             .{ .name = "ztracy_options", .module = options_module },
         },
     });
-    ztracy.addIncludePath(b.path("libs/tracy/tracy"));
+    ztracy.addImport("c", translate_c.createModule());
 
-    const tracy = if (options.shared) b.addSharedLibrary(.{
-        .name = "tracy",
-        .target = target,
-        .optimize = optimize,
-    }) else b.addStaticLibrary(.{
+    const tracy = if (options.shared) blk: {
+        const lib = b.addSharedLibrary(.{
+            .name = "tracy",
+            .target = target,
+            .optimize = optimize,
+        });
+        lib.defineCMacro("TRACY_EXPORTS", "");
+        break :blk lib;
+    } else b.addStaticLibrary(.{
         .name = "tracy",
         .target = target,
         .optimize = optimize,
@@ -61,8 +79,11 @@ pub fn build(b: *std.Build) void {
     if (options.on_demand) tracy.defineCMacro("TRACY_ON_DEMAND", null);
 
     tracy.linkLibC();
-    if (target.result.abi != .msvc)
+    if (target.result.abi != .msvc) {
         tracy.linkLibCpp();
+    } else {
+        tracy.defineCMacro("fileno", "_fileno");
+    }
 
     switch (target.result.os.tag) {
         .windows => {

--- a/libs/ztracy/src/ztracy.zig
+++ b/libs/ztracy/src/ztracy.zig
@@ -252,12 +252,7 @@ const tracy_stub = struct {
 };
 
 const tracy_full = struct {
-    const c = @cImport({
-        //@cDefine("TRACY_CALLSTACK", "8"); Uncomment to enable callstacks. "8" is max depth (can be changed).
-        @cDefine("TRACY_ENABLE", "");
-        @cInclude("TracyC.h");
-    });
-
+    const c = @import("c");
     const has_callstack_support = @hasDecl(c, "TRACY_HAS_CALLSTACK") and @hasDecl(c, "TRACY_CALLSTACK");
     const callstack_depth: c_int = if (has_callstack_support) c.TRACY_CALLSTACK else 0;
 


### PR DESCRIPTION
A few changes for compiling for `x86_64-windows-msvc`.

- zmesh: use the new `@extern` field, `.is_dll_import`, to link the memory allocation functions from a shared library with the -msvc ABI
- zphysics: fix compilation errors on msvc
- zphysics: fix the definition of JPC_CharacterBaseSettings to account for an MSVC padding quirk
- ztracy: fix compilation under .msvc (define `fileno` -> `_fileno` and fixup export / import defines)
- zglfw: add iconify callback (this is unrelated to msvc but I noticed I had this change locally while upstreaming)

The zmesh change depends on a zig version that includes https://github.com/ziglang/zig/pull/21758 (the change I made to add `.is_dll_import`). This change is included with the latest zig tarballs.