### PR TITLE
[zgpu] Add build options for binding limits

### DIFF
--- a/libs/zgpu/build.zig
+++ b/libs/zgpu/build.zig
@@ -13,6 +13,8 @@ const default_options = struct {
     const bind_group_pool_size = 32;
     const bind_group_layout_pool_size = 32;
     const pipeline_layout_pool_size = 32;
+    const max_num_bindings_per_group = 10;
+    const max_num_bind_groups_per_pipeline = 4;
 };
 
 pub fn build(b: *std.Build) void {
@@ -75,6 +77,16 @@ pub fn build(b: *std.Build) void {
             "pipeline_layout_pool_size",
             "Set pipeline layout pool size",
         ) orelse default_options.pipeline_layout_pool_size,
+        .max_num_bindings_per_group = b.option(
+            u32,
+            "max_num_bindings_per_group",
+            "Set maximum number of bindings per bind group",
+        ) orelse default_options.max_num_bindings_per_group,
+        .max_num_bind_groups_per_pipeline = b.option(
+            u32,
+            "max_num_bind_groups_per_pipeline",
+            "Set maximum number of bindings groups per pipeline",
+        ) orelse default_options.max_num_bind_groups_per_pipeline,
     };
 
     const options_step = b.addOptions();

--- a/libs/zgpu/src/zgpu.zig
+++ b/libs/zgpu/src/zgpu.zig
@@ -1346,7 +1346,7 @@ pub const BindGroupEntryInfo = struct {
     texture_view_handle: ?TextureViewHandle = null,
 };
 
-const max_num_bindings_per_group = 10;
+const max_num_bindings_per_group = zgpu_options.max_num_bindings_per_group;
 
 pub const BindGroupInfo = struct {
     gpuobj: ?wgpu.BindGroup = null,
@@ -1362,7 +1362,7 @@ pub const BindGroupLayoutInfo = struct {
         [_]wgpu.BindGroupLayoutEntry{.{ .binding = 0, .visibility = .{} }} ** max_num_bindings_per_group,
 };
 
-const max_num_bind_groups_per_pipeline = 4;
+const max_num_bind_groups_per_pipeline = zgpu_options.max_num_bind_groups_per_pipeline;
 
 pub const PipelineLayoutInfo = struct {
     gpuobj: ?wgpu.PipelineLayout = null,


### PR DESCRIPTION
I hit the default `max_num_bindings_per_group` limit, and was surprised to see the spec calls for a minimum of 640.
Seeing the `BindGroupInfo`/`PipelineLayoutInfo` structs, I understand the limitation, but I think exposing it as build option make sense here.