### PR TITLE
zphysics: support for shape serialization

### DIFF
--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.cpp
@@ -1936,6 +1936,23 @@ JPC_Shape_CastRay(const JPC_Shape *in_shape,
     assert(in_shape && in_ray && in_id_creator && io_hit);
     return toJph(in_shape)->CastRay(*toJph(in_ray), *toJph(in_id_creator), *toJph(io_hit));
 }
+
+JPC_API void
+JPC_Shape_SaveBinaryState(const JPC_Shape* in_shape, void* in_stream_out)
+{
+    assert(in_shape && in_stream_out);
+    return toJph(in_shape)->SaveBinaryState(*static_cast<JPH::StreamOut *>(in_stream_out));
+}
+
+JPC_API JPC_Shape*
+JPC_Shape_sRestoreFromBinaryState(void* in_stream_in)
+{
+	const JPH::Result result = JPH::Shape::sRestoreFromBinaryState(*static_cast<JPH::StreamIn *>(in_stream_in));
+	if (result.HasError()) return nullptr;
+	JPH::Shape* shape = const_cast<JPH::Shape*>(result.Get().GetPtr());
+	shape->AddRef();
+	return toJpc(shape);
+}
 //--------------------------------------------------------------------------------------------------
 //
 // JPC_BoxShape

--- a/libs/zphysics/libs/JoltC/JoltPhysicsC.h
+++ b/libs/zphysics/libs/JoltC/JoltPhysicsC.h
@@ -751,6 +751,36 @@ typedef bool (*JPC_BodyDrawFilterFunc)(const JPC_Body *);
 // Interfaces (virtual tables)
 //
 //--------------------------------------------------------------------------------------------------
+typedef struct JPC_StreamOutVTable
+{
+    _JPC_VTABLE_HEADER;
+
+    // Required, *cannot* be NULL.
+    void
+    (*WriteBytes)(void *in_self, const void *in_data, size_t in_num_bytes);
+	
+    // Required, *cannot* be NULL.
+    bool
+    (*IsFailed)(const void *in_self);
+} JPC_StreamOutVTable;
+
+typedef struct JPC_StreamInVTable
+{
+    _JPC_VTABLE_HEADER;
+
+    // Required, *cannot* be NULL.
+    void
+    (*ReadBytes)(void *in_self, void *out_data, size_t in_num_bytes);
+
+    // Required, *cannot* be NULL.
+    bool
+    (*IsEOF)(const void *in_self);
+	
+    // Required, *cannot* be NULL.
+    bool
+    (*IsFailed)(const void *in_self);
+} JPC_StreamInVTable;
+
 typedef struct JPC_BroadPhaseLayerInterfaceVTable
 {
     _JPC_VTABLE_HEADER;
@@ -1738,6 +1768,15 @@ JPC_Shape_CastRay(const JPC_Shape *in_shape,
                   const JPC_RayCast *in_ray,
                   const JPC_SubShapeIDCreator *in_id_creator,
                   JPC_RayCastResult *io_hit); // *Must* be default initialized (see JPC_RayCastResult)
+
+// `in_stream_out` *must* point to a struct that has JPC_StreamOutVTable as its first member
+JPC_API void
+JPC_Shape_SaveBinaryState(const JPC_Shape* in_shape, void* in_stream_out);
+
+// `in_stream_in` *must* point to a struct that has JPC_StreamInVTable as its first member
+JPC_API JPC_Shape*
+JPC_Shape_sRestoreFromBinaryState(void* in_stream_in); 
+
 //--------------------------------------------------------------------------------------------------
 //
 // JPC_BoxShape


### PR DESCRIPTION
Here are some proposed changes to add support for binary serialization of shapes.

- Add `StreamOut` and `StreamIn` interfaces
- Add implementations of `StreamOut` / `StreamIn` that use `AnyWriter` / `AnyReader`
- Add `Shape::saveBinaryState` and `Shape::RestoreFromBinaryState`

Opening this as a draft as I may be adding support for `SaveMaterialState` and `SaveSubShapeState` depending on if my use case requires it or not. I'm avoiding it for now as the map data structures may be tricky to easily map between C/C++.