### PR TITLE
Fix build.zig.zon and dev.build.zig.zon to be compatible with Zig 0.14.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "zig-gamedev",
+    .name = .zig_gamedev,
     .version = "0.6.0",
     .minimum_zig_version = "0.14.0",
     .paths = .{

--- a/dev.build.zig.zon
+++ b/dev.build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "zig-gamedev",
+    .name = .zig_gamedev,
     .version = "0.6.0",
     .minimum_zig_version = "0.14.0",
     .paths = .{


### PR DESCRIPTION
- Updated `.name=.zig_gamedev` for Zig 0.14.0 compatibility

- The current setup works with 0.14.0-dev.2577 but not with the released 0.14.0